### PR TITLE
feat: Add Cilium component for use with Multus.

### DIFF
--- a/gitops/components/cilium/kustomization.yaml
+++ b/gitops/components/cilium/kustomization.yaml
@@ -19,17 +19,3 @@ patches:
         value:
           namespace: cilium
           server: https://kubernetes.default.svc
-
-#replacements:
-#  - source:
-#      version: v1
-#      kind: ConfigMap
-#      name: kustomize-environment
-#      fieldPath: data.ADOT_ROLE_ARN
-#    targets:
-#      - select:
-#          version: v1
-#          kind: ServiceAccount
-#          name: adot-collector
-#        fieldPaths:
-#          - metadata.annotations.eks\.amazonaws\.com/role-arn

--- a/gitops/components/cilium/kustomization.yaml
+++ b/gitops/components/cilium/kustomization.yaml
@@ -1,0 +1,35 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ./resources.yaml
+
+patches:
+  - target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: AppProject
+      name: admins
+    patch: |-
+      - op: add
+        path: /spec/sourceRepos/-
+        value: https://helm.cilium.io
+      - op: add
+        path: /spec/destinations/-
+        value:
+          namespace: cilium
+          server: https://kubernetes.default.svc
+
+#replacements:
+#  - source:
+#      version: v1
+#      kind: ConfigMap
+#      name: kustomize-environment
+#      fieldPath: data.ADOT_ROLE_ARN
+#    targets:
+#      - select:
+#          version: v1
+#          kind: ServiceAccount
+#          name: adot-collector
+#        fieldPaths:
+#          - metadata.annotations.eks\.amazonaws\.com/role-arn

--- a/gitops/components/cilium/resources.yaml
+++ b/gitops/components/cilium/resources.yaml
@@ -21,9 +21,10 @@ spec:
     targetRevision: 1.14.4
     helm:
       releaseName: cilium
-      values: |
-        cni:
-          exclusive: false
-          customConf: true
-        nodeSelector:
-          pelo.tech/multi-home-networking: "true"
+      parameters:
+        - name: cni.exclusive
+          value: "false"
+        - name: cni.customConf
+          value: "true"
+        - name: nodeSelector
+          value: 'pelo.tech/multi-home-networking: "true"'

--- a/gitops/components/cilium/resources.yaml
+++ b/gitops/components/cilium/resources.yaml
@@ -25,12 +25,5 @@ spec:
         cni:
           exclusive: false
           customConf: true
-        nodeinit:
-          affinity:
-            nodeAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: pelo.tech/multi-home-networking
-                        operator: Exists
-
+        nodeSelector:
+          pelo.tech/multi-home-networking: "true"

--- a/gitops/components/cilium/resources.yaml
+++ b/gitops/components/cilium/resources.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cilium
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: admins
+  destination:
+    namespace: cilium
+    name: in-cluster
+  syncPolicy:
+    automated: {}
+    syncOptions:
+      - CreateNamespace=true
+  source:
+    chart: cilium
+    repoURL: https://helm.cilium.io
+    targetRevision: 1.14.4
+    helm:
+      releaseName: cilium
+      values: |-
+        cni:
+          exclusive: false
+          customConf: true
+        nodeinit:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: pelo.tech/multi-home-networking
+                        operator: Exists
+

--- a/gitops/components/cilium/resources.yaml
+++ b/gitops/components/cilium/resources.yaml
@@ -21,7 +21,7 @@ spec:
     targetRevision: 1.14.4
     helm:
       releaseName: cilium
-      values: |-
+      values: |
         cni:
           exclusive: false
           customConf: true

--- a/gitops/components/cilium/resources.yaml
+++ b/gitops/components/cilium/resources.yaml
@@ -27,4 +27,4 @@ spec:
         - name: cni.customConf
           value: "true"
         - name: nodeSelector
-          value: 'pelo.tech/multi-home-networking: "true"'
+          value: '{"pelo.tech/multi-home-networking": "true"}'

--- a/gitops/components/cilium/resources.yaml
+++ b/gitops/components/cilium/resources.yaml
@@ -22,9 +22,24 @@ spec:
     helm:
       releaseName: cilium
       parameters:
-        - name: cni.exclusive
-          value: "false"
-        - name: cni.customConf
-          value: "true"
-        - name: nodeSelector
-          value: '{"pelo.tech/multi-home-networking": "true"}'
+        - name: clusterName
+          value: CLUSTER_NAME
+        - name: awsRegion
+          value: AWS_REGION
+        # - name: serviceAccounts.cilium.annotations
+        #   value: AMP_RW_ENDPOINT
+        # TODO: how to express a map with multiple dot-separated keys as a value here?
+        # eks.amazonaws.com/role-arn: CILIUM_ROLE_ARN
+        # eks.amazonaws.com/sts-regional-endpoints: "true"
+      values: |
+        cni:
+          exclusive: "false"
+          customConf: "true"
+        nodeSelector:
+          kubernetes.io/os: linux
+          pelo.tech/multi-home-networking: "true"
+#        serviceAccounts:
+#          cilium:
+#            annotations:
+#              eks.amazonaws.com/role-arn: CILIUM_ROLE_ARN
+#              eks.amazonaws.com/sts-regional-endpoints: "true"

--- a/gitops/components/multus/kustomize/nidhogg/kustomization.yaml
+++ b/gitops/components/multus/kustomize/nidhogg/kustomization.yaml
@@ -16,6 +16,13 @@ resources:
   - ./rbac.yaml
   - ./leader-election-rbac.yaml
 
+#patches:
+# Expose the prometheus metrics on default port
+#  - target:
+#      group: apps
+#      version: v1
+#      kind: StatefulSet
+#    path: ./overlays/nidhogg-statefulset-prometheus-patch.yaml
 
 images:
   - name: controller

--- a/gitops/components/multus/kustomize/overlays/multus-daemonset-patch.yaml
+++ b/gitops/components/multus/kustomize/overlays/multus-daemonset-patch.yaml
@@ -13,3 +13,8 @@
   value:
     key: pelo.tech/multi-home-networking
     operator: Exists
+# TODO: use `nodeSelector` instead of `nodeAffinity`
+#- op: add
+#  path: /spec/template/spec/nodeSelector
+#  value:
+#    pelo.tech/multi-home-networking: "true"


### PR DESCRIPTION
Cilium is configured to install itself but not update CNI config on the host. This is to support Multus driving the Cilium config dynamically via `NetworkAttachmentDefinition` CRDs.