### PR TITLE
fix: Specify `AWS_REGION` to support cert-manager GovCloud.

### DIFF
--- a/gitops/base-install/cert-manager/install.yaml
+++ b/gitops/base-install/cert-manager/install.yaml
@@ -33,6 +33,10 @@ spec:
           value: "true"
         - name: serviceAccount.create
           value: "false"
+        - name: extraEnv.0.name
+          value: "AWS_REGION"
+        - name: extraEnv.0.value
+          value: "us-east-1"
         - name: serviceAccount.name
           value: "cert-manager"
         - name: securityContext.fsGroup


### PR DESCRIPTION
This should be specified on the certificate issuer, but it didn't seem to take effect. Maybe we didn't test correctly and it would work with a clean test, but we don't actually know how to perform a clean test.