### PR TITLE
fix: namespace the nlb name to match the cluster name to be unique

### DIFF
--- a/gitops/base-install/ingress-controller/overlays/ingress-nginx-controller-service.yaml
+++ b/gitops/base-install/ingress-controller/overlays/ingress-nginx-controller-service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: ingress-nginx
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
-    service.beta.kubernetes.io/aws-load-balancer-name: nginx-nlb
+    service.beta.kubernetes.io/aws-load-balancer-name: NLB_NAME
     service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"

--- a/gitops/base-install/replacements/kustomization.yaml
+++ b/gitops/base-install/replacements/kustomization.yaml
@@ -93,6 +93,19 @@ replacements:
       version: v1
       kind: ConfigMap
       name: kustomize-environment
+      fieldPath: data.CLUSTER_NAME
+    targets:
+      - select:
+          version: v1
+          kind: Service
+          name: ingress-nginx-controller
+        fieldPaths:
+          - metadata.annotations.[service.beta.kubernetes.io/aws-load-balancer-name]
+
+  - source:
+      version: v1
+      kind: ConfigMap
+      name: kustomize-environment
       fieldPath: data.EBS_CSI_ROLE_ARN
     targets:
       - select:


### PR DESCRIPTION
FYI on the update to make the NLB based on the cluster name instead of hardcoded