### PR TITLE
Revert "bump KubeVirt to 1.3.0"

### DIFF
--- a/gitops/components/kubevirt/kustomize/operators/kustomization.yaml
+++ b/gitops/components/kubevirt/kustomize/operators/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/kubevirt/kubevirt/releases/download/v1.3.0/kubevirt-operator.yaml
+  - https://github.com/kubevirt/kubevirt/releases/download/v1.2.0/kubevirt-operator.yaml
   - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.59.0/cdi-operator.yaml
 
 commonAnnotations:


### PR DESCRIPTION
This reverts commit 892a29317bc7c0af1d4b1acb33a347742ceccf69.