### PR TITLE
feat: relocating metrics port for nidhogg manager to avoid conflicts

### DIFF
--- a/gitops/components/nidhogg/overlays/nidhogg-controller-manager.yaml
+++ b/gitops/components/nidhogg/overlays/nidhogg-controller-manager.yaml
@@ -8,3 +8,9 @@
 - op: add
   path: /spec/template/spec/hostNetwork
   value: true
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --metrics-addr=8081
+- op: replace
+  path: /spec/template/spec/containers/0/ports/1/containerPort
+  value: 8081


### PR DESCRIPTION
Tested with `kustomize build .` 

OUTPUT :
```
...
apiVersion: apps/v1
kind: StatefulSet
metadata:
  labels:
    control-plane: controller-manager
    controller-tools.k8s.io: "1.0"
  name: nidhogg-controller-manager
  namespace: nidhogg-system
spec:
  replicas: 2
  selector:
    matchLabels:
      control-plane: controller-manager
      controller-tools.k8s.io: "1.0"
  serviceName: nidhogg-controller-manager-service
  template:
    metadata:
      labels:
        control-plane: controller-manager
        controller-tools.k8s.io: "1.0"
    spec:
      containers:
      - args:
        - --config-file=/config/config.json
        - --leader-election
        - --leader-namespace=nidhogg-system
        - --leader-configmap=nidhogg-election
        - --metrics-addr=8081
        command:
        - /manager
        env:
        - name: POD_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        - name: SECRET_NAME
          value: nidhogg-webhook-server-secret
        image: ghcr.io/pelotech/nidhogg:v0.5.1
        imagePullPolicy: Always
        name: manager
        ports:
        - containerPort: 9876
          name: webhook-server
          protocol: TCP
        - containerPort: 8081
          name: metrics
          protocol: TCP
...
```

Closes #98 