### PR TITLE
feat: expand kubevirt disks feature gate

### DIFF
--- a/gitops/components/kubevirt/kustomize/resources.yaml
+++ b/gitops/components/kubevirt/kustomize/resources.yaml
@@ -51,6 +51,7 @@ spec:
         - Sidecar
         - VMExport
         - LiveMigration
+        - ExpandDisks
 #        - CommonInstancetypesDeploymentGate
   customizeComponents:
     patches:


### PR DESCRIPTION
I ran into this [issue](https://github.com/kubevirt/containerized-data-importer/issues/930) where after a dv smart clone and resize, the guest fs does not reflect the larger size of the target pvc, it is still at the smaller source pvc size.

Eventually https://github.com/kubevirt/kubevirt/pull/5981 was merged which is behind this feature gate. 

Docs: https://kubevirt.io/user-guide/storage/disks_and_volumes/#disk-expansion