### PR TITLE
feat: move dv cloning permissions to a cluster role

### DIFF
--- a/gitops/components/kubevirt/kustomize/resources.yaml
+++ b/gitops/components/kubevirt/kustomize/resources.yaml
@@ -24,6 +24,15 @@ spec:
     nodeSelector:
       kubernetes.io/os: linux
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "cdi:data-volumes:clone"
+rules:
+  - apiGroups: ["cdi.kubevirt.io"]
+    resources: ["datavolumes/source"]
+    verbs: ["create"]
+---
 apiVersion: kubevirt.io/v1
 kind: KubeVirt
 metadata:


### PR DESCRIPTION
We’re currently recreating a role for each namespace containing the VM image cache, to make mergeable these namespaces, we want to define this role only once as a ClusterRole

Namespaces cloning DVs will bind this ClusterRole to their default SA using a RoleBinding to keep these permissions namespaced.