### PR TITLE
chore: bump ArgoCD to v2.13.1

### DIFF
--- a/gitops/base-install/argocd/cluster-install/kustomization.yaml
+++ b/gitops/base-install/argocd/cluster-install/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://raw.githubusercontent.com/argoproj/argo-cd/v2.11.3/manifests/install.yaml
+- https://raw.githubusercontent.com/argoproj/argo-cd/v2.13.1/manifests/install.yaml
 
 namespace: argocd
 labels:

--- a/gitops/base-install/argocd/ha-install/kustomization.yaml
+++ b/gitops/base-install/argocd/ha-install/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://raw.githubusercontent.com/argoproj/argo-cd/v2.11.3/manifests/ha/install.yaml
+- https://raw.githubusercontent.com/argoproj/argo-cd/v2.13.1/manifests/ha/install.yaml
 
 
 namespace: argocd


### PR DESCRIPTION
This will allow using ref values with Helm `--set-file` / ArgoCD `fileParameters`