### PR TITLE
fix: remove hostnetwork from nidhogg

### DIFF
--- a/gitops/components/nidhogg/overlays/nidhogg-controller-manager.yaml
+++ b/gitops/components/nidhogg/overlays/nidhogg-controller-manager.yaml
@@ -16,6 +16,3 @@
                 operator: NotIn
                 values:
                   - "metal"
-- op: add
-  path: /spec/template/spec/hostNetwork
-  value: true


### PR DESCRIPTION
nidhogg shouldn't need to be on the hostnetwork since it doesn't have any webhooks