### PR TITLE
fix: revert "bump Multus to v4.2.2 (#270)"

### DIFF
--- a/gitops/components/multus/kustomization.yaml
+++ b/gitops/components/multus/kustomization.yaml
@@ -2,11 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 resources:
-  - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/refs/tags/v4.2.2/deployments/multus-daemonset.yml
+  - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/refs/tags/v3.9.3/deployments/multus-daemonset.yml
 
 images:
   - name: ghcr.io/k8snetworkplumbingwg/multus-cni
-    newTag: v4.2.2
+    newTag: v3.9.3
 
 patches:
   - target:


### PR DESCRIPTION
This reverts commit 9d023c9bb479678e08f7c893a8e61eaa693b849a.

Using static routes in the NAD instead of the Multus annotation, being applied to all resources, we discovered at build time issues with VMs, despite it fixes it for containers—following kube-ovn's recommendations, we want to fix this Multus annotation instead of using special NADs