### PR TITLE
feat: Adding FIPS mode for OpenSSL on nginx ingress

### DIFF
--- a/gitops/base-install/ingress-controller/resources.yaml
+++ b/gitops/base-install/ingress-controller/resources.yaml
@@ -77,6 +77,12 @@ spec:
             default: true
           extraArgs:
             enable-ssl-passthrough: "" # https://github.com/kubernetes/ingress-nginx/issues/8052
+          extraEnvs:
+            # Note this is a bit belt and suspenders as the default list here:
+            # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#ssl-ciphers
+            # is also a FIPS-140 but this blocks non-FIPS completely.
+            - name: OPENSSL_FIPS
+              value: "1"
           config:
             strict-validate-path-type: false # https://github.com/kubernetes/ingress-nginx/issues/11176
             enable-real-ip: "true" # https://github.com/kubernetes/ingress-nginx/issues/8052


### PR DESCRIPTION
This is a bit belt and suspenders as the default list here: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#ssl-ciphers should also be secure but this goes a step further and prevents OpenSSL from using any non-FIPS-140 algorithms at all.