### PR TITLE
feat!: switch http node port to 81 to support pod identity on port 80

### DIFF
--- a/gitops/components/aws-alb-nginx/resources.yaml
+++ b/gitops/components/aws-alb-nginx/resources.yaml
@@ -65,6 +65,8 @@ spec:
       releaseName: ingress-nginx
       valuesObject:
         controller:
+          containerPort:
+            http: 81 # stupid pod identity uses port 80
           hostNetwork: true
           service:
             annotations:
@@ -76,6 +78,7 @@ spec:
           ingressClassResource:
             default: true
           extraArgs:
+            http-port: 81 # stupid pod identity uses port 80
             enable-ssl-passthrough: "" # https://github.com/kubernetes/ingress-nginx/issues/8052
           config:
             strict-validate-path-type: false # https://github.com/kubernetes/ingress-nginx/issues/11176


### PR DESCRIPTION
We'll need to move away from nginx in general - however for now we need to start switching the node ports away from 80 and to 81 (or another port?) so we can add pod identity which runs on port 80 - https://github.com/aws/eks-pod-identity-agent/issues/10

manual steps for existing alb nginx ingress - configs
1. delete the apiVersion: elbv2.k8s.aws/v1beta1 kind: TargetGroupBinding for the existing port (should validate this is actually needed? might just need the other two steps and will self heal)
2. delete the listener from the lb balancer for port 80
3. delete the target group for port 80

everything should self heal after a few minutes
