### PR TITLE
chore(grafana): enable kube_pod_container_status_restarts_total

### DIFF
--- a/gitops/components/grafana-k8s-monitoring/resources.yaml
+++ b/gitops/components/grafana-k8s-monitoring/resources.yaml
@@ -88,7 +88,6 @@ spec:
                 - kube_persistentvolume_status_phase
                 - kube_persistentvolumeclaim_info
                 - kube_persistentvolumeclaim_status_phase
-                - kube_pod_container_status_restarts_total
                 - kube_pod_spec_volumes_persistentvolumeclaims_info
                 - kube_pod_start_time
                 - kube_pod_status_reason


### PR DESCRIPTION
This metric is useful for alerting whenever a container restarts due to OOMKilled:
```
(changes(kube_pod_container_status_restarts_total[15m]) > 0)
* on(namespace, pod) group_left(reason) kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}
```