### PR TITLE
feat: add envoy-gateway as foundation component

### DIFF
--- a/gitops/base-install/argocd/resources.yaml
+++ b/gitops/base-install/argocd/resources.yaml
@@ -43,6 +43,7 @@ spec:
     - https://aws.github.io/eks-charts # alb/nlb
     - https://kubernetes.github.io/ingress-nginx # ingress-nginx
     - registry-1.docker.io/bitnamicharts # multus
+    - docker.io/envoyproxy # envoy gateway
   destinations:
     - namespace: cert-manager
       server: https://kubernetes.default.svc
@@ -51,6 +52,8 @@ spec:
     - namespace: alb
       server: https://kubernetes.default.svc
     - namespace: ingress-nginx
+      server: https://kubernetes.default.svc
+    - namespace: envoy-gateway-system
       server: https://kubernetes.default.svc
     - namespace: kube-system # multus
       server: https://kubernetes.default.svc

--- a/gitops/components/envoy-gateway/kustomization.yaml
+++ b/gitops/components/envoy-gateway/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ./resources.yaml
+
+replacements:
+  - source:
+      version: v1
+      kind: ConfigMap
+      name: kustomize-environment
+      # TODO: once nginx ingress migration is complete, EG_NLB_NAME can be replaced with CLUSTER_NAME
+      fieldPath: data.EG_NLB_NAME
+    targets:
+      - select:
+          group: gateway.envoyproxy.io
+          version: v1alpha1
+          kind: EnvoyProxy
+          name: eg-proxy
+        fieldPaths:
+          - spec.provider.kubernetes.envoyService.annotations.[service.beta.kubernetes.io/aws-load-balancer-name]

--- a/gitops/components/envoy-gateway/resources.yaml
+++ b/gitops/components/envoy-gateway/resources.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: envoy-gateway
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: networking
+  source:
+    chart: gateway-helm
+    repoURL: docker.io/envoyproxy
+    targetRevision: v1.7.1
+    helm:
+      releaseName: envoy-gateway
+  destination:
+    namespace: envoy-gateway-system
+    name: in-cluster
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+    automated: {}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: eg
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: eg-proxy
+    namespace: envoy-gateway-system
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: eg-proxy
+  namespace: envoy-gateway-system
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyService:
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+          # TODO: once nginx ingress migration is complete, EG_NLB_NAME can be replaced with CLUSTER_NAME
+          service.beta.kubernetes.io/aws-load-balancer-name: EG_NLB_NAME
+          service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
+          service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+          service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"

--- a/gitops/components/external-dns/resources.yaml
+++ b/gitops/components/external-dns/resources.yaml
@@ -27,6 +27,10 @@ spec:
         env:
           - name: AWS_DEFAULT_REGION
             value: us-east-1
+        sources:
+          - service
+          - ingress
+          - gateway-httproute
         policy: sync
         registry: txt
         txtPrefix: xdns-


### PR DESCRIPTION
## Summary

Adds Envoy Gateway as a foundation component following the same pattern as `aws-alb-nginx`, delivering the ArgoCD Application, GatewayClass, and EnvoyProxy as cluster infrastructure. The `Gateway` itself is left to the cluster
operator, consistent with the [Gateway API hierarchy](https://gateway-api.sigs.k8s.io/#introduction)

<img width="717" height="510" alt="image" src="https://github.com/user-attachments/assets/e268f996-b8ad-4dec-8df6-a15bab3b63b1" />

ArgoCD Application values sourced from the [official install docs](https://gateway.envoyproxy.io/docs/install/install-argocd/).

`GatewayClass` has no mechanism for passing annotations to downstream services. The `EnvoyProxy` CRD fills this gap. NLB annotations are set via `spec.provider.kubernetes.envoyService.annotations` which are applied to the data plane service created per Gateway.

`EG_NLB_NAME` is used instead of `CLUSTER_NAME` to avoid NLB name collision during migrations where nginx ingress and EG coexist. Once migration is complete this can be consolidated to `CLUSTER_NAME`.

Also adds gateway-httproute as a source to the external-dns component. This is inert until a cluster has HTTPRoutes and a Gateway with the `external-dns.alpha.kubernetes.io/target` annotation, but is required for the eventual per-cluster DNS cutover from nginx ingress to EG.

## What cluster operators need to do
- Add `EG_NLB_NAME` to `_base/environment.yaml`
- Add the component to their kustomization
- Define their own `Gateway` with listeners and cert refs

## Test plan
- [ ] GatewayClass `eg` accepted by EG controller
- [ ] EnvoyProxy `eg-proxy` created with correct NLB annotations on data plane service