### PR TITLE
feat: enable Gateway API support for cert manager

### DIFF
--- a/gitops/components/cert-manager/resources.yaml
+++ b/gitops/components/cert-manager/resources.yaml
@@ -16,6 +16,8 @@ spec:
       releaseName: cert-manager
       valuesObject:
         installCRDs: true
+        config:
+          enableGatewayAPI: true
         serviceAccount:
           create: true
           name: cert-manager


### PR DESCRIPTION
Adds `config.enableGatewayAPI: true` to the cert-manager helm values, enabling cert-manager to provision certificates for Gateway API resources via cert-manager.io/cluster-issuer annotations on Gateway listeners.

Without this flag, certificates must be managed manually in Gateway environments.

References: [cert-manager Gateway API docs](https://cert-manager.io/docs/usage/gateway/)