### PR TITLE
fix: use sync wave -1 to ensure eg installs first

### DIFF
--- a/gitops/components/envoy-gateway/resources.yaml
+++ b/gitops/components/envoy-gateway/resources.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: envoy-gateway
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io


### PR DESCRIPTION
Before use of GatawayClass and EnvoyProxy.