### PR TITLE
fix: use sync wave -1 for eg install and skip dry run check for CRDs

### DIFF
--- a/gitops/components/envoy-gateway/resources.yaml
+++ b/gitops/components/envoy-gateway/resources.yaml
@@ -3,6 +3,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: envoy-gateway
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
@@ -27,6 +29,8 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: eg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   controllerName: gateway.envoyproxy.io/gatewayclass-controller
   parametersRef:
@@ -40,6 +44,8 @@ kind: EnvoyProxy
 metadata:
   name: eg-proxy
   namespace: envoy-gateway-system
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   provider:
     type: Kubernetes


### PR DESCRIPTION
Ensures EG installs and CRDs land before GatewayClass and EnvoyProxy are applied, using sync wave -1 and SkipDryRunOnMissingResource to handle the bootstrap ordering problem.