### PR TITLE
fix: switch EG NLB target type to instance

### DIFF
--- a/gitops/components/envoy-gateway/resources.yaml
+++ b/gitops/components/envoy-gateway/resources.yaml
@@ -56,5 +56,7 @@ spec:
           # TODO: once nginx ingress migration is complete, EG_NLB_NAME can be replaced with CLUSTER_NAME
           service.beta.kubernetes.io/aws-load-balancer-name: EG_NLB_NAME
           service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
+          # nlb-target-type: ip requires pod IPs to be registered as EC2 ENIs, which depends
+          # on the CNI and IPAM configuration. Instance mode targets nodes via NodePort instead.
           service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
           service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"

--- a/gitops/components/envoy-gateway/resources.yaml
+++ b/gitops/components/envoy-gateway/resources.yaml
@@ -56,5 +56,5 @@ spec:
           # TODO: once nginx ingress migration is complete, EG_NLB_NAME can be replaced with CLUSTER_NAME
           service.beta.kubernetes.io/aws-load-balancer-name: EG_NLB_NAME
           service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
-          service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+          service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
           service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"


### PR DESCRIPTION
Problem: With `nlb-target-type: ip`, the ALB controller must register pod IPs directly as NLB targets. This requires pod IPs to exist as EC2 ENIs. On clusters using Cilium with default cluster-pool IPAM, pod IPs are allocated from an
internal pool and have no EC2 presence, confirmed by querying EC2 directly for the pod IP, which returned empty. [ENI mode is available](https://docs.cilium.io/en/stable/network/concepts/ipam/eni/) as an alternative but is a cluster wide change.

The ALB controller logged a repeating error and never registered any targets, leaving the NLB with all targets unhealthy and requests hanging.

```
cannot resolve pod ENI for pods: [envoy-gateway-system/envoy-envoy-gateway-system-eg-5391c79d-69fd8777d4-fr2rx]
```

hostNetwork: true would sidestep this (as nginx does), but EG removed that option at v1.0.

Fix: Switch to `nlb-target-type: instance`. The NLB targets nodes directly via NodePort. Node IPs are always registered in EC2. The ALB controller no longer needs to resolve pod ENIs. Verified on core-prod: targets now register and the NLB shows a healthy target, via manual Argo edit.