### PR TITLE
fix: remove gateway API defaults from cert-manager and external-dns

### DIFF
--- a/gitops/components/cert-manager/resources.yaml
+++ b/gitops/components/cert-manager/resources.yaml
@@ -16,8 +16,6 @@ spec:
       releaseName: cert-manager
       valuesObject:
         installCRDs: true
-        config:
-          enableGatewayAPI: true
         serviceAccount:
           create: true
           name: cert-manager

--- a/gitops/components/external-dns/resources.yaml
+++ b/gitops/components/external-dns/resources.yaml
@@ -27,10 +27,6 @@ spec:
         env:
           - name: AWS_DEFAULT_REGION
             value: us-east-1
-        sources:
-          - service
-          - ingress
-          - gateway-httproute
         policy: sync
         registry: txt
         txtPrefix: xdns-


### PR DESCRIPTION
Both `cert-manager` (`enableGatewayAPI: true`) and `external-dns` (`sources: [gateway-httproute]`) were configured by default to require Gateway API CRDs to be installed. If a client does not use Gateway API, these settings cause the pods to crash.

These were opt-in features that should not be forced on all clients.

- Removed `config.enableGatewayAPI: true` from `cert-manager` helm values. The chart defaults to `false`
- Removed `gateway-httproute` from `external-dns` sources. The chart defaults to `[service, ingress]`

Clients who use Gateway API (e.g. with Envoy Gateway) should add patches in their own kustomization to re-enable these settings.