### PR TITLE
feat(envoy-gateway): make chart source and image refs kustomizable

### DIFF
--- a/gitops/components/envoy-gateway/kustomization.yaml
+++ b/gitops/components/envoy-gateway/kustomization.yaml
@@ -19,3 +19,55 @@ replacements:
           name: eg-proxy
         fieldPaths:
           - spec.provider.kubernetes.envoyService.annotations.[service.beta.kubernetes.io/aws-load-balancer-name]
+  - source:
+      version: v1
+      kind: ConfigMap
+      name: kustomize-environment
+      fieldPath: data.EG_REPO_URL
+    targets:
+      - select:
+          group: argoproj.io
+          version: v1alpha1
+          kind: Application
+          name: envoy-gateway
+        fieldPaths:
+          - spec.source.repoURL
+  - source:
+      version: v1
+      kind: ConfigMap
+      name: kustomize-environment
+      fieldPath: data.EG_TARGET_REVISION
+    targets:
+      - select:
+          group: argoproj.io
+          version: v1alpha1
+          kind: Application
+          name: envoy-gateway
+        fieldPaths:
+          - spec.source.targetRevision
+  - source:
+      version: v1
+      kind: ConfigMap
+      name: kustomize-environment
+      fieldPath: data.EG_GATEWAY_IMAGE
+    targets:
+      - select:
+          group: argoproj.io
+          version: v1alpha1
+          kind: Application
+          name: envoy-gateway
+        fieldPaths:
+          - spec.source.helm.valuesObject.global.images.envoyGateway.image
+  - source:
+      version: v1
+      kind: ConfigMap
+      name: kustomize-environment
+      fieldPath: data.EG_RATELIMIT_IMAGE
+    targets:
+      - select:
+          group: argoproj.io
+          version: v1alpha1
+          kind: Application
+          name: envoy-gateway
+        fieldPaths:
+          - spec.source.helm.valuesObject.global.images.ratelimit.image

--- a/gitops/components/envoy-gateway/kustomization.yaml
+++ b/gitops/components/envoy-gateway/kustomization.yaml
@@ -23,19 +23,6 @@ replacements:
       version: v1
       kind: ConfigMap
       name: kustomize-environment
-      fieldPath: data.EG_REPO_URL
-    targets:
-      - select:
-          group: argoproj.io
-          version: v1alpha1
-          kind: Application
-          name: envoy-gateway
-        fieldPaths:
-          - spec.source.repoURL
-  - source:
-      version: v1
-      kind: ConfigMap
-      name: kustomize-environment
       fieldPath: data.EG_TARGET_REVISION
     targets:
       - select:
@@ -45,29 +32,3 @@ replacements:
           name: envoy-gateway
         fieldPaths:
           - spec.source.targetRevision
-  - source:
-      version: v1
-      kind: ConfigMap
-      name: kustomize-environment
-      fieldPath: data.EG_GATEWAY_IMAGE
-    targets:
-      - select:
-          group: argoproj.io
-          version: v1alpha1
-          kind: Application
-          name: envoy-gateway
-        fieldPaths:
-          - spec.source.helm.valuesObject.global.images.envoyGateway.image
-  - source:
-      version: v1
-      kind: ConfigMap
-      name: kustomize-environment
-      fieldPath: data.EG_RATELIMIT_IMAGE
-    targets:
-      - select:
-          group: argoproj.io
-          version: v1alpha1
-          kind: Application
-          name: envoy-gateway
-        fieldPaths:
-          - spec.source.helm.valuesObject.global.images.ratelimit.image

--- a/gitops/components/envoy-gateway/resources.yaml
+++ b/gitops/components/envoy-gateway/resources.yaml
@@ -12,10 +12,17 @@ spec:
   project: networking
   source:
     chart: gateway-helm
-    repoURL: docker.io/envoyproxy
-    targetRevision: v1.7.1
+    repoURL: REPLACE_EG_REPO_URL
+    targetRevision: REPLACE_EG_TARGET_REVISION
     helm:
       releaseName: envoy-gateway
+      valuesObject:
+        global:
+          images:
+            envoyGateway:
+              image: REPLACE_EG_GATEWAY_IMAGE
+            ratelimit:
+              image: REPLACE_EG_RATELIMIT_IMAGE
   destination:
     namespace: envoy-gateway-system
     name: in-cluster

--- a/gitops/components/envoy-gateway/resources.yaml
+++ b/gitops/components/envoy-gateway/resources.yaml
@@ -12,17 +12,10 @@ spec:
   project: networking
   source:
     chart: gateway-helm
-    repoURL: REPLACE_EG_REPO_URL
-    targetRevision: REPLACE_EG_TARGET_REVISION
+    repoURL: docker.io/envoyproxy
+    targetRevision: v1.8.0
     helm:
       releaseName: envoy-gateway
-      valuesObject:
-        global:
-          images:
-            envoyGateway:
-              image: REPLACE_EG_GATEWAY_IMAGE
-            ratelimit:
-              image: REPLACE_EG_RATELIMIT_IMAGE
   destination:
     namespace: envoy-gateway-system
     name: in-cluster


### PR DESCRIPTION
## Summary

- Makes the Envoy Gateway chart source (`repoURL`, `targetRevision`) and runtime images (`gateway-dev`, `ratelimit`) kustomizable via the `kustomize-environment` ConfigMap
- Allows clusters to swap in a custom chart and pinned image digests without modifying the foundation component directly

## Motivation

Gateway API v1.5 introduces stable `ListenerSet` support, which enables per-namespace listener delegation, a significant improvement over the current model of centrally managing all listeners in a single Gateway resource. The versioned EG releases (latest: v1.7.2) only bundle Gateway API v1.4.1. A custom chart will be published to `ghcr.io/pelotech/charts/gateway-helm` based on the `v0.0.0-latest` EG build which includes Gateway API v1.5.1.

This change makes it possible to test that custom chart on specific clusters before EG ships a versioned release with Gateway API v1.5 support.

## Changes

- `resources.yaml` — replaced hardcoded `repoURL`, `targetRevision`, and image values with `REPLACE_*` sentinels
- `kustomization.yaml` — added replacements for `EG_REPO_URL`, `EG_TARGET_REVISION`, `EG_GATEWAY_IMAGE`, `EG_RATELIMIT_IMAGE`

## Required ConfigMap keys

Each cluster using this component must define the following in its `kustomize-environment` ConfigMap:

```yaml
EG_NLB_NAME: <value>
EG_REPO_URL: <value>           # e.g. ghcr.io/pelotech or docker.io/envoyproxy
EG_TARGET_REVISION: <value>    # e.g. v1.8.0-rc.0 or v1.7.2
EG_GATEWAY_IMAGE: <value>      # full image ref with digest
EG_RATELIMIT_IMAGE: <value>    # full image ref with digest
```
