### PR TITLE
feat(cert-manager): add gateway API http01 solver support to create-issuer

### DIFF
--- a/gitops/components/cert-manager/create-issuer/Chart.yaml
+++ b/gitops/components/cert-manager/create-issuer/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0

--- a/gitops/components/cert-manager/create-issuer/templates/create-issuer.yaml
+++ b/gitops/components/cert-manager/create-issuer/templates/create-issuer.yaml
@@ -13,8 +13,19 @@ spec:
       name: {{ .Values.issuerName }}
     solvers:
       - http01:
+          {{- if and .Values.ingressClassName (not .Values.gateway.enabled) }}
           ingress:
             class: {{ .Values.ingressClassName }}
+          {{- end }}
+          {{- if .Values.gateway.enabled }}
+          {{- if not (and .Values.gateway.name .Values.gateway.namespace) }}
+          {{- fail ".gateway.name and .gateway.namespace are required when gateway.enabled is true" }}
+          {{- end }}
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: {{ .Values.gateway.name }}
+                namespace: {{ .Values.gateway.namespace }}
+          {{- end }}
       - dns01:
           route53:
             region: {{ .Values.awsRegion }}

--- a/gitops/components/cert-manager/create-issuer/values.yaml
+++ b/gitops/components/cert-manager/create-issuer/values.yaml
@@ -1,5 +1,8 @@
 issuerName: letsencrypt
-acmeIssuerServer: https://acme-v02.api.letsencrypt.org/directory
 acmeIssuerEmail: ""
 awsRegion: "us-west-2"
 ingressClassName: nginx
+gateway:
+  enabled: false
+  name: ""
+  namespace: ""


### PR DESCRIPTION
Clusters running cert-manager with Gateway API enabled (`enableGatewayAPI: true`) eventually need the `ClusterIssuer` to use a `gatewayHTTPRoute` solver instead of an `ingress` solver. The requirement was to add this without changing behavior for any existing consumer. Existing installs rely on the default `ingressClassName: nginx` and must continue to render identically.

## How the chart handles each scenario
| Situation | Result |
|---|---|
| Default values (no gateway config) | Ingress solver with `class: nginx` — identical to prior behaviour |
| `gateway.enabled: true` + name + namespace | Gateway solver rendered, ingress suppressed |
| `gateway.enabled: true` with `ingressClassName` still at default | Gateway wins, ingress suppressed — no need to null out `ingressClassName` |
| `gateway.enabled: true` but missing `name` or `namespace` | Hard fail with descriptive error |

`gateway.enabled: true` has priority over `ingressClassName`. Consumers only need to set gateway values. They do not need to know about or clear the `ingressClassName` default.

`acmeIssuerServer` was also removed from `values.yaml`. It was never referenced in the template (the ACME server URL is hardcoded), so it was a dead value that implied configurability that didn't exist.

## Test commands
All commands run from `gitops/components/cert-manager/create-issuer`.

### 1. No diff against main (existing clients unaffected)
```bash
helm template test . > /tmp/main.yaml
helm template test . > /tmp/branch.yaml
diff /tmp/main.yaml /tmp/branch.yaml
# expect: helm chart version diff, otherwise identical
```

### 2. Default values produce ingress solver
```bash
helm template test .
# expect: ingress.class = nginx, no gatewayHTTPRoute
```

### 3. Gateway enabled — ingress suppressed, gateway rendered
```bash
helm template test . --set gateway.enabled=true --set gateway.name=my-gateway --set gateway.namespace=networking
# expect: gatewayHTTPRoute with parentRefs name=my-gateway namespace=networking, no ingress block
```

### 4. Gateway enabled with ingressClassName still at default — gateway wins
```bash
helm template test . --set gateway.enabled=true --set gateway.name=my-gateway --set gateway.namespace=networking \
  --set ingressClassName=nginx
# expect: same as scenario 3 — gateway wins, no ingress block
```

### 5. Gateway enabled but name missing — hard fail
```bash
helm template test . --set gateway.enabled=true --set gateway.namespace=networking
# expect: Error: .gateway.name and .gateway.namespace are required when gateway.enabled is true
```

### 6. Gateway enabled but namespace missing — hard fail
```bash
helm template test . --set gateway.enabled=true --set gateway.name=my-gateway
# expect: Error: .gateway.name and .gateway.namespace are required when gateway.enabled is true
```
