### PR TITLE
chore(grafana-k8s-monitoring): remove duplicate cluster label and instance label

### DIFF
--- a/gitops/components/grafana-k8s-monitoring/resources.yaml
+++ b/gitops/components/grafana-k8s-monitoring/resources.yaml
@@ -35,6 +35,7 @@ spec:
               create: false
               name: prometheus
               namespace: grafana-k8s-monitoring
+            clusterLabels: [cluster] # https://github.com/grafana/k8s-monitoring-helm/issues/1308#issuecomment-2898457019
           - name: logsService
             type: loki
             url: LOKI_ENDPOINT
@@ -44,6 +45,7 @@ spec:
               create: false
               name: loki
               namespace: grafana-k8s-monitoring
+            clusterLabels: [cluster]
           - name: tracesService
             type: otlp
             protocol: grpc
@@ -60,6 +62,7 @@ spec:
               create: false
               name: tempo
               namespace: grafana-k8s-monitoring
+            clusterLabels: [cluster]
 
         # https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-pod-logs
         podLogs:
@@ -119,6 +122,10 @@ spec:
               rule {
                 action = "labeldrop"
                 regex = "image_spec"
+              }
+              rule {
+                action = "labeldrop"
+                regex = "instance"
               }
               rule {
                 action = "labeldrop"


### PR DESCRIPTION
It's a copy of the cluster label already available, needlessly increasing usage: https://github.com/grafana/k8s-monitoring-helm/issues/1308#issuecomment-2898457019

Also removes the `instance` label which isn't useful, it's just the ip:port of the metrics exporter