### PR TITLE
chore: remove EG_TARGET_REVISION replacement, hardcode stable v1.8.0

### DIFF
--- a/gitops/components/envoy-gateway/kustomization.yaml
+++ b/gitops/components/envoy-gateway/kustomization.yaml
@@ -19,16 +19,3 @@ replacements:
           name: eg-proxy
         fieldPaths:
           - spec.provider.kubernetes.envoyService.annotations.[service.beta.kubernetes.io/aws-load-balancer-name]
-  - source:
-      version: v1
-      kind: ConfigMap
-      name: kustomize-environment
-      fieldPath: data.EG_TARGET_REVISION
-    targets:
-      - select:
-          group: argoproj.io
-          version: v1alpha1
-          kind: Application
-          name: envoy-gateway
-        fieldPaths:
-          - spec.source.targetRevision


### PR DESCRIPTION
- Removes the `EG_TARGET_REVISION` replacement from the envoy-gateway component, pinning `targetRevision` to the stable `v1.8.0` directly in `resources.yaml`
- Clients no longer need to supply `EG_TARGET_REVISION` in their `kustomize-environment` ConfigMap

The replacement was requiring every client to carry `EG_TARGET_REVISION` as a mandatory key — Kustomize replacements have no default fallback mechanism. Omitting the key produces a hard build error:

```
fieldPath data.EG_TARGET_REVISION is missing for replacement source ConfigMap.v1.[noGrp]/kustomize-environment.[noNs]
```

Since `v1.8.0` will be released soon, pinning it in the component directly is simpler and removes the burden from clients.

This can be merged once EG 1.8 is officially released.