### PR TITLE
feat: add traefik ingress replacement with automated gateway integrations

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -10,3 +10,4 @@ rules:
 ignore: |
   *.terraform/
   gitops/components/cert-manager/create-issuer/templates/create-issuer.yaml
+  gitops/components/envoy-gateway/create-gateway/templates/gateway.yaml

--- a/docs/GATEWAY-ADOPTION.md
+++ b/docs/GATEWAY-ADOPTION.md
@@ -46,7 +46,7 @@ In Argo (`argocd` application), ensure your `GatewayClass` and `EnvoyProxy` obje
 
 3. Verify the Gateway API stack (no manual controller changes are needed)
 
-The `Gateway` itself (name `eg`, namespace `envoy-gateway-system`) is created
+The `Gateway` itself (name `external`, namespace `envoy-gateway-system`) is created
 **automatically** by the component's `create-gateway` chart, including an
 `acme-solver` listener on port 80 for the Let's Encrypt http01 solver. No
 per-cluster Gateway YAML is needed.
@@ -161,7 +161,7 @@ You can prepare a [cutover from Ingress -> Gateway](https://www.pelotech.com/pos
 ### Cert Manager Gateway Issuer
 
 The envoy-gateway component **automatically** adds a labeled gateway solver to
-the `letsencrypt` ClusterIssuer (`parentRefs: eg/envoy-gateway-system`,
+the `letsencrypt` ClusterIssuer (`parentRefs: external/envoy-gateway-system`,
 selected by the `use-gateway-solver: "true"` label — see the
 [ListenerSet annotations](#cert-manager-annotations) above). The Ingress
 solver remains the default; no `create-issuer` patch is needed. The same

--- a/docs/GATEWAY-ADOPTION.md
+++ b/docs/GATEWAY-ADOPTION.md
@@ -9,6 +9,16 @@ application from Ingress to Gateway API is **optional and per-app** — this
 document covers enabling the Gateway API stack on a cluster and, for apps that
 want it, the cutover choreography.
 
+> ⚠️ **Maturity: switch cautiously.** While the Gateway API resources this
+> platform uses (`Gateway`, `HTTPRoute`, `ListenerSet`) are GA in the spec,
+> key integrations are still **beta**: cert-manager's Gateway support is
+> officially a beta feature (its `ListenerSet` support only since `v1.20`,
+> gated behind feature flags), and external-dns's TLS/TCP/UDP route sources
+> ride deprecated alpha APIs. Ingress remains the battle-tested default path.
+> Move apps one at a time, keep the weighted-DNS rollback in place until a
+> host has proven itself, and treat certificate issuance and DNS record
+> creation as the things to verify — they cross the beta surfaces.
+
 ## Initial Per-Cluster Steps
 
 Each numbered step should be a discrete PR.
@@ -109,6 +119,42 @@ Use the following annotations on `HTTPRoutes` when using AWS Route53 and Weighte
 
 * `external-dns.alpha.kubernetes.io/aws-weight: "0"`
 * `external-dns.alpha.kubernetes.io/set-identifier: unique-name` (be sure to use a real unique name and not `unique-name`)
+
+Placement matters: these must be on the **Route** (or `Ingress`) object, never
+the `Gateway` — external-dns reads only the `target` annotation from Gateway
+objects and silently ignores routing-policy annotations placed there
+([a documented common mistake](https://kubernetes-sigs.github.io/external-dns/v0.21.0/docs/annotations/annotations/)).
+
+#### Certificates During Weighted Cutover (use dns01)
+
+**http01 does not work reliably while a host's DNS is split between two data
+planes.** Let's Encrypt validates from multiple network vantage points
+([Multi-Perspective Issuance Corroboration](https://letsencrypt.org/2025/02/20/first-mpic-request/),
+mandatory for all CAs since 2025), and each vantage point resolves DNS
+independently — under a weighted split they land on different NLBs, but
+cert-manager presents each challenge through only one solver/data plane, so
+the corroboration quorum fails. There is also a chicken-and-egg at weight `0`:
+Route53 never returns a zero-weight record, so the ListenerSet's new
+Certificate (a separate cert/secret from the Ingress-side one) cannot issue
+via http01 *before* traffic shifts — you would cut over to a listener with no
+certificate.
+
+The supported pattern is the **dns01 solver**, which is independent of where
+traffic lands:
+
+1. When creating the `ListenerSet`, add the label
+   `use-dns01-solver: "true"` (alongside the `cert-manager.io/cluster-issuer`
+   annotation). The Certificate inherits the label and issues via Route53
+   immediately — at weight `0`, before any traffic moves.
+2. Verify the certificate is issued and the AWS listener healthy, then start
+   shifting weights. Renewals during the weighted window also use dns01 and
+   are unaffected by the split.
+3. Once the host is at 100% on the Gateway, optionally remove the label to
+   fall back to the gateway http01 solver (`use-gateway-solver: "true"`).
+
+The traefik/ingress-nginx publishService switch is **not** affected by any of
+this: both controllers serve the same solver `Ingress` objects (class
+`nginx`), so http01 challenges answer on either NLB throughout that cutover.
 
 You can prepare a [cutover from Ingress -> Gateway](https://www.pelotech.com/post/ingress-nginx-migration) by annotating `Ingress` objects with `100` weight and the new `HTTPRoutes` with `0` weight, and then flip weights once ready.
 

--- a/docs/GATEWAY-ADOPTION.md
+++ b/docs/GATEWAY-ADOPTION.md
@@ -1,4 +1,13 @@
-# Gateway Migration Steps
+# Gateway API Adoption
+
+The platform supports **both the Ingress API and the Gateway API for the
+foreseeable future**: Ingress is served by the [`traefik`
+component](../gitops/components/traefik/README.md) (nginx-compatible,
+replacing the retired ingress-nginx controller), and the Gateway API by the
+[`envoy-gateway` component](../gitops/components/envoy-gateway/). Moving an
+application from Ingress to Gateway API is **optional and per-app** — this
+document covers enabling the Gateway API stack on a cluster and, for apps that
+want it, the cutover choreography.
 
 ## Initial Per-Cluster Steps
 
@@ -14,7 +23,7 @@ Each numbered step should be a discrete PR.
 In Argo (`argocd` application), check the  `infrastructure` `AppProject` is healthy and updated.
 
 2. Install Envoy Gateway
-    * In `kustomization.yaml`, add `https://github.com/pelotech/foundation//gitops/components/envoy-gateway?ref=v4.3.3` to the `components` array, replacing the version with the current version
+    * In `kustomization.yaml`, add `https://github.com/pelotech/foundation//gitops/components/envoy-gateway?ref=v4.3.3` to the `components` array, replacing the version with the current version. **Order matters**: list it *after* the `cert-manager` and `external-dns` components — the envoy-gateway component patches both, and kustomize silently skips patches whose targets aren't accumulated yet
     * In `_base/environment.yaml` add `EG_NLB_NAME: "eg-CLUSTER-NAME"` (subbing in your `CLUSTER-NAME`, e.g. `eg-foundation-nonprod`) to the `kustomize-environment` `ConfigMap`
     * In `rbac.yaml` in the `viewonly-access` `ClusterRole`, add the following values to the `rules.apiGroups` array:
 
@@ -25,7 +34,7 @@ In Argo (`argocd` application), check the  `infrastructure` `AppProject` is heal
 
 In Argo (`argocd` application), ensure your `GatewayClass` and `EnvoyProxy` objects exist and are healthy. You may also want to check the updated `ConfigMap` and `ClusterRole`.
 
-3. Update controllers (these could be split up into multiple PRs if desired)
+3. Verify the Gateway API stack (no manual controller changes are needed)
 
 The `Gateway` itself (name `eg`, namespace `envoy-gateway-system`) is created
 **automatically** by the component's `create-gateway` chart, including an
@@ -81,7 +90,7 @@ You can check your new routes (without flipping weight) by editing your hosts fi
 
 Use the following annotations on `ListenerSets` when using Cert Manager with Let's Encrypt:
 
-* `acme.cert-manager.io/http01-parentreffallback: "true"` - Note: use of this annotation will require a version of Cert Manager > `v1.20.2`. As of the time of this writing, a version/image with this functionality has not yet been released
+* `acme.cert-manager.io/http01-parentreffallback: "true"` - requires cert-manager `v1.21+` (the cert-manager component ships `v1.21.0`)
 * `cert-manager.io/cluster-issuer: letsencrypt`
 
 If the ClusterIssuer defines a labeled gateway solver (see the
@@ -113,14 +122,24 @@ solver remains the default; no `create-issuer` patch is needed. The same
 ordering rule applies: the cert-manager component must be listed *before*
 `envoy-gateway`, or the patch is silently skipped.
 
-Once all `Ingress` are gone from a cluster, patch the `create-issuer`
-Application to drop the Ingress solver (making the gateway solver the
-default). See the
+Both solvers coexist indefinitely — the Ingress solver serves Ingress-based
+apps, the labeled gateway solver serves Gateway API apps. (Only in the
+unlikely case a cluster retires the Ingress API entirely would you patch
+`create-issuer` to drop the Ingress solver.) See the
 [create-issuer README](https://github.com/pelotech/foundation/blob/main/gitops/components/cert-manager/create-issuer/README.md)
 for all available solver options and combinations.
 
 Also be sure your Gateway has a [Listener for the challenge/solver on port 80](#gateway-certificate-challenge-acme-solver).
 
-### Final Steps
+### Per-App Cleanup
 
-Once all `Ingress` are cutover, you will need to ensure those are deleted, and the Ingress Controller is uninstalled from the cluster.
+Once an app's traffic has fully cut over to its `HTTPRoute`, delete that app's
+old `Ingress` object so external-dns doesn't manage competing records for the
+hostname.
+
+There is **no requirement to move every app**: the Ingress API remains a
+supported, first-class surface served by the maintained
+[`traefik` component](../gitops/components/traefik/README.md). What must be
+retired is only the EOL **ingress-nginx controller** — that happens via the
+traefik component's publishService switch and is independent of any app's
+Ingress-vs-Gateway choice (see the traefik README's cutover section).

--- a/docs/GATEWAY-MIGRATION.md
+++ b/docs/GATEWAY-MIGRATION.md
@@ -25,105 +25,39 @@ In Argo (`argocd` application), check the  `infrastructure` `AppProject` is heal
 
 In Argo (`argocd` application), ensure your `GatewayClass` and `EnvoyProxy` objects exist and are healthy. You may also want to check the updated `ConfigMap` and `ClusterRole`.
 
-3. Create a Gateway and update controllers (these could be split up into multiple PRs if desired)
-    * Add `async-cluster-configuration/resources/envoy-gateway.yaml`
+3. Update controllers (these could be split up into multiple PRs if desired)
 
-``` yaml
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: eg
-  namespace: envoy-gateway-system
-spec:
-  gatewayClassName: eg
-  allowedListeners:
-    namespaces:
-      from: All
-  # keep this placeholder until https://github.com/kubernetes-sigs/gateway-api/issues/4425 is resolved
-  listeners:
-    - name: placeholder
-      port: 65535
-      protocol: HTTP
-      hostname: placeholder.invalid
-      allowedRoutes:
-        namespaces:
-          from: Selector
-          selector:
-            matchLabels:
-              placeholder: placeholder
-```
+The `Gateway` itself (name `eg`, namespace `envoy-gateway-system`) is created
+**automatically** by the component's `create-gateway` chart, including an
+`acme-solver` listener on port 80 for the Let's Encrypt http01 solver. No
+per-cluster Gateway YAML is needed.
 
 #### Gateway Certificate Challenge (ACME Solver)
 
-If you are using Let's Encrypt for certificates and are planning to use [`gatewayHTTPRoute`](https://github.com/pelotech/foundation/blob/688e1b6c97113b6183f93f6a21208f594daa5519/gitops/components/cert-manager/create-issuer/templates/create-issuer.yaml#L24) for your solver, listeners should be replaced with the following:
+The `acme-solver` listener is on by default. If a cluster must not expose port
+80 (e.g. dns01-only), disable it by patching the `envoy-gateway` Application's
+`create-gateway` source values with `gateway.acmeSolver: false` — a
+placeholder listener is rendered instead (a Gateway currently requires at
+least one listener; see
+[gateway-api#4425](https://github.com/kubernetes-sigs/gateway-api/issues/4425)).
+Extra cluster-level listeners can be added via `gateway.extraListeners`;
+per-host TLS should use `ListenerSets`.
 
-``` yaml
-  listeners:
-    - name: acme-solver
-      port: 80
-      protocol: HTTP
-      allowedRoutes:
-        namespaces:
-          from: All
-```
+* cert-manager's Gateway API + ListenerSet support and external-dns's Gateway
+  API route sources (`gateway-httproute`, `gateway-grpcroute`,
+  `gateway-tlsroute`, `gateway-tcproute`, `gateway-udproute`, with ListenerSet
+  traversal) are enabled **automatically** by the envoy-gateway component — no
+  cert-manager or external-dns patches are needed. **Ordering matters**: the
+  cert-manager and external-dns components must be listed *before*
+  `envoy-gateway` in your `components:` array; if one is missing or listed
+  after, kustomize silently skips that patch — gateway certificates won't
+  issue / gateway DNS records won't publish. Notes: TCP/UDP routes carry no
+  hostnames, so their records require the
+  `external-dns.alpha.kubernetes.io/hostname` annotation on the route; the
+  external-dns patch replaces the whole `sources` list, so clusters with
+  custom sources should re-patch the full list after the component.
 
-* Add `- resources/envoy-gateway.yaml` to the `resources` array in `async-cluster-configuration/kustomization.yaml`:
-
-* Create `_base/overlays/cert-manager-patch.yaml` with the following values:
-
-
-``` yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: cert-manager
-spec:
-  source:
-    helm:
-      valuesObject:
-        config:
-          enableGatewayAPI: true
-          enableGatewayAPIListenerSet: true
-          featureGates:
-            ListenerSets: true
-```
-
-* Create `_base/overlays/external-dns-patch.yaml` with the following values:
-
-``` yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: external-dns
-spec:
-  source:
-    helm:
-      valuesObject:
-        sources:
-          - service
-          - ingress
-          - gateway-httproute
-        enableGatewayListenerSets: true
-```
-
-* In `kustomization.yaml`, add the following to the `patches` array:
-
-``` yaml
-  - target:
-      group: argoproj.io
-      version: v1alpha1
-      kind: Application
-      name: cert-manager
-    path: _base/overlays/cert-manager-patch.yaml
-  - target:
-      group: argoproj.io
-      version: v1alpha1
-      kind: Application
-      name: external-dns
-    path: _base/overlays/external-dns-patch.yaml
-```
-
-In Argo (`async-cluster-configuration` application), ensure your `Gateway` object exists and is healthy. You may also want to check the `cert-manager` and `external-dns` applications.
+In Argo (`envoy-gateway` application), ensure your `Gateway` object exists and is healthy. You may also want to check the `cert-manager` and `external-dns` applications.
 
 In AWS, in the EC2 page, ensure your new load balancer exists. If you have a `Listener` on port 80 for Let's Encrypt, you can ensure a `Listener` exists with at least one `Healthy` `Target Group` (it is OK to have unhealthy `Target Groups` as long as one is healthy).
 
@@ -150,6 +84,16 @@ Use the following annotations on `ListenerSets` when using Cert Manager with Let
 * `acme.cert-manager.io/http01-parentreffallback: "true"` - Note: use of this annotation will require a version of Cert Manager > `v1.20.2`. As of the time of this writing, a version/image with this functionality has not yet been released
 * `cert-manager.io/cluster-issuer: letsencrypt`
 
+If the ClusterIssuer defines a labeled gateway solver (see the
+[create-issuer README](https://github.com/pelotech/foundation/blob/main/gitops/components/cert-manager/create-issuer/README.md)),
+also add the matching **label** (not annotation) so Certificates created from
+the ListenerSet select the gateway solver instead of the default Ingress
+solver:
+
+* `use-gateway-solver: "true"` — Certificates inherit labels from the
+  annotated ListenerSet/Gateway, and cert-manager picks solvers by label
+  match, never by which controller requested the cert.
+
 #### External DNS Annotations
 
 Use the following annotations on `HTTPRoutes` when using AWS Route53 and Weighted Routing:
@@ -161,37 +105,19 @@ You can prepare a [cutover from Ingress -> Gateway](https://www.pelotech.com/pos
 
 ### Cert Manager Gateway Issuer
 
-An important late migration step is to ensure Cert Manager uses Gateway to issue Let's Encrypt certs. The `gateway` values are not wired up as replacements in the component, so you need to patch the `create-issuer` ArgoCD Application directly.
+The envoy-gateway component **automatically** adds a labeled gateway solver to
+the `letsencrypt` ClusterIssuer (`parentRefs: eg/envoy-gateway-system`,
+selected by the `use-gateway-solver: "true"` label — see the
+[ListenerSet annotations](#cert-manager-annotations) above). The Ingress
+solver remains the default; no `create-issuer` patch is needed. The same
+ordering rule applies: the cert-manager component must be listed *before*
+`envoy-gateway`, or the patch is silently skipped.
 
-Create `_base/overlays/create-issuer-patch.yaml`:
-
-``` yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: create-issuer
-spec:
-  source:
-    helm:
-      valuesObject:
-        gateway:
-          enabled: true
-          name: eg
-          namespace: envoy-gateway-system
-```
-
-Then add the patch to the `patches` array in `kustomization.yaml`:
-
-``` yaml
-  - target:
-      group: argoproj.io
-      version: v1alpha1
-      kind: Application
-      name: create-issuer
-    path: _base/overlays/create-issuer-patch.yaml
-```
-
-See the [create-issuer values](https://github.com/pelotech/foundation/blob/688e1b6c97113b6183f93f6a21208f594daa5519/gitops/components/cert-manager/create-issuer/values.yaml#L6-L8) for all available gateway options.
+Once all `Ingress` are gone from a cluster, patch the `create-issuer`
+Application to drop the Ingress solver (making the gateway solver the
+default). See the
+[create-issuer README](https://github.com/pelotech/foundation/blob/main/gitops/components/cert-manager/create-issuer/README.md)
+for all available solver options and combinations.
 
 Also be sure your Gateway has a [Listener for the challenge/solver on port 80](#gateway-certificate-challenge-acme-solver).
 

--- a/gitops/base-install/argocd/resources.yaml
+++ b/gitops/base-install/argocd/resources.yaml
@@ -44,6 +44,7 @@ spec:
     - https://kubernetes.github.io/ingress-nginx # ingress-nginx
     - registry-1.docker.io/bitnamicharts # multus
     - docker.io/envoyproxy # envoy gateway
+    - ghcr.io/traefik/helm # traefik
   destinations:
     - namespace: cert-manager
       server: https://kubernetes.default.svc
@@ -54,6 +55,8 @@ spec:
     - namespace: ingress-nginx
       server: https://kubernetes.default.svc
     - namespace: envoy-gateway-system
+      server: https://kubernetes.default.svc
+    - namespace: traefik
       server: https://kubernetes.default.svc
     - namespace: kube-system # multus
       server: https://kubernetes.default.svc

--- a/gitops/components/aws-alb-nginx/README.md
+++ b/gitops/components/aws-alb-nginx/README.md
@@ -1,5 +1,11 @@
 # Cluster Ingress controller
 
+> **Deprecated aggregate**: this component has been split into
+> [`aws-alb`](../aws-alb/README.md) (AWS Load Balancer Controller, shared by
+> all ingress data planes) and [`ingress-nginx`](../ingress-nginx/README.md)
+> (EOL, migration window only). It is kept as a backwards-compatible aggregate
+> of both. New clusters should use `aws-alb` + [`traefik`](../traefik/README.md).
+
 This directory defines a configuration to provide Ingress support on the
 cluster. This configuration is specific to an AWS environment where TLS
 termination is handled by Nginx on the cluster (as opposed to terminating TLS

--- a/gitops/components/aws-alb-nginx/kustomization.yaml
+++ b/gitops/components/aws-alb-nginx/kustomization.yaml
@@ -1,48 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
-resources:
-  - ./resources.yaml
-
-replacements:
-  - source:
-      version: v1
-      kind: ConfigMap
-      name: kustomize-environment
-      fieldPath: data.CLUSTER_NAME
-    targets:
-      - select:
-          group: argoproj.io
-          version: v1alpha1
-          kind: Application
-          name: alb-controller
-        fieldPaths:
-          - spec.source.helm.valuesObject.clusterName
-
-  - source:
-      version: v1
-      kind: ConfigMap
-      name: kustomize-environment
-      fieldPath: data.ALB_ROLE_ARN
-    targets:
-      - select:
-          group: argoproj.io
-          version: v1alpha1
-          kind: Application
-          name: alb-controller
-        fieldPaths:
-          - spec.source.helm.valuesObject.serviceAccount.annotations.[eks.amazonaws.com/role-arn]
-
-  - source:
-      version: v1
-      kind: ConfigMap
-      name: kustomize-environment
-      fieldPath: data.CLUSTER_NAME
-    targets:
-      - select:
-          group: argoproj.io
-          version: v1alpha1
-          kind: Application
-          name: ingress-nginx-controller
-        fieldPaths:
-          - spec.source.helm.valuesObject.controller.service.annotations.[service.beta.kubernetes.io/aws-load-balancer-name]
+# Backwards-compatible aggregate: this component was split into aws-alb
+# (AWS Load Balancer Controller, shared by all ingress data planes) and
+# ingress-nginx (EOL, kept for the migration window). Existing consumers
+# keep working; new clusters should use aws-alb + traefik instead.
+components:
+  - ../aws-alb
+  - ../ingress-nginx

--- a/gitops/components/aws-alb/README.md
+++ b/gitops/components/aws-alb/README.md
@@ -1,0 +1,20 @@
+# AWS Load Balancer Controller
+
+Deploys the [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/),
+which reconciles `Service` objects carrying `service.beta.kubernetes.io/aws-load-balancer-*`
+annotations into AWS NLBs.
+
+This is the **shared base** for every ingress data plane in this repo — the
+`ingress-nginx`, `traefik`, and `envoy-gateway` components all create
+LoadBalancer Services that this controller turns into NLBs. Enable it before
+(or alongside) any of them.
+
+## Required `kustomize-environment` keys
+
+| Key | Purpose |
+|---|---|
+| `CLUSTER_NAME` | EKS cluster name for the controller |
+| `ALB_ROLE_ARN` | IRSA role ARN for the controller's ServiceAccount |
+
+Formerly bundled with ingress-nginx in the `aws-alb-nginx` component, which now
+aggregates `aws-alb` + `ingress-nginx` for backwards compatibility.

--- a/gitops/components/aws-alb/kustomization.yaml
+++ b/gitops/components/aws-alb/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ./resources.yaml
+
+replacements:
+  - source:
+      version: v1
+      kind: ConfigMap
+      name: kustomize-environment
+      fieldPath: data.CLUSTER_NAME
+    targets:
+      - select:
+          group: argoproj.io
+          version: v1alpha1
+          kind: Application
+          name: alb-controller
+        fieldPaths:
+          - spec.source.helm.valuesObject.clusterName
+
+  - source:
+      version: v1
+      kind: ConfigMap
+      name: kustomize-environment
+      fieldPath: data.ALB_ROLE_ARN
+    targets:
+      - select:
+          group: argoproj.io
+          version: v1alpha1
+          kind: Application
+          name: alb-controller
+        fieldPaths:
+          - spec.source.helm.valuesObject.serviceAccount.annotations.[eks.amazonaws.com/role-arn]

--- a/gitops/components/aws-alb/resources.yaml
+++ b/gitops/components/aws-alb/resources.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: alb-controller
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: networking
+  source:
+    chart: aws-load-balancer-controller
+    repoURL: https://aws.github.io/eks-charts
+    targetRevision: 3.4.2
+    helm:
+      releaseName: aws-load-balancer-controller
+      valuesObject:
+        hostNetwork: true
+        metricsBindAddr: ':8085'
+        serviceAccount:
+          create: "true"
+          name: "aws-load-balancer-controller"
+          annotations:
+            eks.amazonaws.com/role-arn: ALB_ROLE_ARN
+            eks.amazonaws.com/sts-regional-endpoints: "true"
+        clusterName: CLUSTER_NAME
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "100m"
+            memory: "128Mi"
+        tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+#        watchNamespace: ingress-nginx # NOTE: Currently disabled however may need to bring back to limit aws lb controller.
+  ignoreDifferences:
+    - kind: Secret
+      name: aws-load-balancer-tls
+      jqPathExpressions:
+        - .data
+  destination:
+    namespace: alb
+    name: in-cluster
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated: {}

--- a/gitops/components/cert-manager/create-issuer/README.md
+++ b/gitops/components/cert-manager/create-issuer/README.md
@@ -1,0 +1,74 @@
+# create-issuer
+
+Renders the `letsencrypt` `ClusterIssuer` with **composable ACME solvers**:
+any mix of http01-via-Ingress (nginx, traefik, ...), http01-via-Gateway
+(envoy-gateway / Gateway API), and dns01 (route53) — simultaneously or alone.
+
+## How solver selection works
+
+cert-manager picks **one solver per Certificate**, choosing the entry whose
+`selector` matches most specifically (`matchLabels` on the Certificate/Ingress,
+or `dnsZones` against the hostname). An entry with **no** `matchLabels`/
+`dnsZones` is the default/catch-all — the chart fails rendering if more than
+one entry is selector-less.
+
+## Values
+
+```yaml
+solvers:
+  ingress:              # one http01 Ingress solver per entry
+    - class: nginx      # selector-less -> the default solver
+  gateway:              # one http01 gatewayHTTPRoute solver per entry
+    - name: eg
+      namespace: envoy-gateway-system
+      matchLabels:
+        use-gateway-solver: "true"
+  dns01:                # route53; region comes from awsRegion
+    enabled: true
+    matchLabels:
+      use-dns01-solver: "true"
+```
+
+`acmeIssuerEmail` and `awsRegion` are wired from the `kustomize-environment`
+ConfigMap (`ACME_ISSUER_EMAIL`, `AWS_REGION`) by the cert-manager component.
+
+## Recipes
+
+* **Default (nginx-served Ingress + labeled dns01)** — the shipped values.
+  Note the [`traefik`](../../traefik/README.md) component serves class `nginx`
+  via its nginx-compat provider, so this default also covers traefik-only
+  clusters unchanged.
+* **All three at once** — keep the nginx default entry, add labeled entries;
+  Certificates opt into a specific solver via labels:
+
+  ```yaml
+  solvers:
+    ingress:
+      - class: nginx
+    gateway:
+      - name: eg
+        namespace: envoy-gateway-system
+        matchLabels:
+          use-gateway-solver: "true"
+    dns01:
+      enabled: true
+      matchLabels:
+        use-dns01-solver: "true"
+  ```
+
+* **Envoy Gateway only** — a single selector-less gateway entry
+  (`ingress: []`, `dns01.enabled` as desired). Requires cert-manager's
+  `config.enableGatewayAPI` — see
+  [GATEWAY-MIGRATION.md](../../../../docs/GATEWAY-MIGRATION.md).
+* **Native-Traefik class** — only when running Traefik's native provider
+  (not the nginx-compat mode this repo defaults to): `- class: traefik`.
+* **dns01 routing** — label Certificates `use-dns01-solver: "true"` (as
+  today), or replace `matchLabels` with `dnsZones` to route whole zones.
+
+## Migration from the previous values schema
+
+| Old | New |
+|---|---|
+| `ingressClassName: X` | `solvers.ingress: [{class: X}]` |
+| `gateway: {enabled: true, name: N, namespace: NS}` | `solvers.gateway: [{name: N, namespace: NS}]` |
+| dns01 (always on, labeled) | `solvers.dns01: {enabled: true, matchLabels: {use-dns01-solver: "true"}}` |

--- a/gitops/components/cert-manager/create-issuer/README.md
+++ b/gitops/components/cert-manager/create-issuer/README.md
@@ -1,74 +1,48 @@
 # create-issuer
 
 Renders the `letsencrypt` `ClusterIssuer` with **composable ACME solvers**:
-any mix of http01-via-Ingress (nginx, traefik, ...), http01-via-Gateway
-(envoy-gateway / Gateway API), and dns01 (route53) — simultaneously or alone.
+any mix of http01-via-Ingress, http01-via-Gateway, and dns01 (route53) —
+simultaneously or alone. `acmeIssuerEmail` and `awsRegion` are wired from the
+`kustomize-environment` ConfigMap (`ACME_ISSUER_EMAIL`, `AWS_REGION`) by the
+cert-manager component.
 
 ## How solver selection works
 
 cert-manager picks **one solver per Certificate**, choosing the entry whose
-`selector` matches most specifically (`matchLabels` on the Certificate/Ingress,
-or `dnsZones` against the hostname). An entry with **no** `matchLabels`/
-`dnsZones` is the default/catch-all — the chart fails rendering if more than
-one entry is selector-less.
+`selector` matches most specifically: `matchLabels` against the Certificate's
+labels (shim-created Certificates inherit them from the annotated
+Ingress/Gateway/ListenerSet), or `dnsZones` against the hostname — use
+`dnsZones` to route whole domains to a solver without labeling anything. An
+entry with **no** `matchLabels`/`dnsZones` is the default/catch-all; the chart
+fails rendering if more than one entry is selector-less.
 
-## Values
+## Configuration
+
+One reference example — every solver type together:
 
 ```yaml
 solvers:
-  ingress:              # one http01 Ingress solver per entry
-    - class: nginx      # selector-less -> the default solver
-  gateway:              # one http01 gatewayHTTPRoute solver per entry
-    - name: eg
-      namespace: envoy-gateway-system
+  ingress:                # shipped default: serves all unlabeled Certificates.
+    - class: nginx        # covers traefik clusters too - the traefik component's
+                          # nginx-compat provider serves class `nginx`.
+                          # `- class: traefik` only for a native-provider Traefik.
+  gateway:                # shipped default is [] - the envoy-gateway component
+    - name: eg            # ADDS THIS ENTRY AUTOMATICALLY (with the label below);
+      namespace: envoy-gateway-system  # only configure it by hand to override.
       matchLabels:
         use-gateway-solver: "true"
-  dns01:                # route53; region comes from awsRegion
-    enabled: true
+  dns01:                  # shipped default: route53, label-selected. Required
+    enabled: true         # during weighted cutovers - see GATEWAY-ADOPTION.md.
     matchLabels:
       use-dns01-solver: "true"
 ```
 
-`acmeIssuerEmail` and `awsRegion` are wired from the `kustomize-environment`
-ConfigMap (`ACME_ISSUER_EMAIL`, `AWS_REGION`) by the cert-manager component.
+Notes:
 
-## Recipes
-
-* **Default (nginx-served Ingress + labeled dns01)** — the shipped values.
-  Note the [`traefik`](../../traefik/README.md) component serves class `nginx`
-  via its nginx-compat provider, so this default also covers traefik-only
-  clusters unchanged.
-* **All three at once** — keep the nginx default entry, add labeled entries;
-  Certificates opt into a specific solver via labels:
-
-  ```yaml
-  solvers:
-    ingress:
-      - class: nginx
-    gateway:
-      - name: eg
-        namespace: envoy-gateway-system
-        matchLabels:
-          use-gateway-solver: "true"
-    dns01:
-      enabled: true
-      matchLabels:
-        use-dns01-solver: "true"
-  ```
-
-* **Envoy Gateway only** — a single selector-less gateway entry
-  (`ingress: []`, `dns01.enabled` as desired). Requires cert-manager's
-  `config.enableGatewayAPI` — see
+* **Gateway-only cluster**: `ingress: []` plus a single selector-less gateway
+  entry. cert-manager's Gateway API feature flags are enabled automatically by
+  the [envoy-gateway component](../../envoy-gateway/) — see
   [GATEWAY-ADOPTION.md](../../../../docs/GATEWAY-ADOPTION.md).
-* **Native-Traefik class** — only when running Traefik's native provider
-  (not the nginx-compat mode this repo defaults to): `- class: traefik`.
-* **dns01 routing** — label Certificates `use-dns01-solver: "true"` (as
-  today), or replace `matchLabels` with `dnsZones` to route whole zones.
-
-## Migration from the previous values schema
-
-| Old | New |
-|---|---|
-| `ingressClassName: X` | `solvers.ingress: [{class: X}]` |
-| `gateway: {enabled: true, name: N, namespace: NS}` | `solvers.gateway: [{name: N, namespace: NS}]` |
-| dns01 (always on, labeled) | `solvers.dns01: {enabled: true, matchLabels: {use-dns01-solver: "true"}}` |
+* Certificates opt into a labeled solver by carrying its label
+  (`use-gateway-solver`, `use-dns01-solver`); everything else gets the
+  selector-less default.

--- a/gitops/components/cert-manager/create-issuer/README.md
+++ b/gitops/components/cert-manager/create-issuer/README.md
@@ -59,7 +59,7 @@ ConfigMap (`ACME_ISSUER_EMAIL`, `AWS_REGION`) by the cert-manager component.
 * **Envoy Gateway only** — a single selector-less gateway entry
   (`ingress: []`, `dns01.enabled` as desired). Requires cert-manager's
   `config.enableGatewayAPI` — see
-  [GATEWAY-MIGRATION.md](../../../../docs/GATEWAY-MIGRATION.md).
+  [GATEWAY-ADOPTION.md](../../../../docs/GATEWAY-ADOPTION.md).
 * **Native-Traefik class** — only when running Traefik's native provider
   (not the nginx-compat mode this repo defaults to): `- class: traefik`.
 * **dns01 routing** — label Certificates `use-dns01-solver: "true"` (as

--- a/gitops/components/cert-manager/create-issuer/README.md
+++ b/gitops/components/cert-manager/create-issuer/README.md
@@ -27,7 +27,7 @@ solvers:
                           # nginx-compat provider serves class `nginx`.
                           # `- class: traefik` only for a native-provider Traefik.
   gateway:                # shipped default is [] - the envoy-gateway component
-    - name: eg            # ADDS THIS ENTRY AUTOMATICALLY (with the label below);
+    - name: external      # ADDS THIS ENTRY AUTOMATICALLY (with the label below);
       namespace: envoy-gateway-system  # only configure it by hand to override.
       matchLabels:
         use-gateway-solver: "true"

--- a/gitops/components/cert-manager/create-issuer/templates/_helpers.tpl
+++ b/gitops/components/cert-manager/create-issuer/templates/_helpers.tpl
@@ -12,3 +12,43 @@ Common labels
 helm.sh/chart: {{ include "create-issuer.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+
+{{/*
+Fail rendering on invalid solver combinations: at least one solver must be
+configured, and at most one entry across all solver types may omit selectors
+(that entry is the default/catch-all — more than one is ambiguous).
+*/}}
+{{- define "create-issuer.validate" -}}
+{{- $entries := concat (.Values.solvers.ingress | default list) (.Values.solvers.gateway | default list) -}}
+{{- if .Values.solvers.dns01.enabled -}}
+{{- $entries = append $entries .Values.solvers.dns01 -}}
+{{- end -}}
+{{- if not $entries -}}
+{{- fail "no solvers configured: set at least one of solvers.ingress, solvers.gateway, solvers.dns01.enabled" -}}
+{{- end -}}
+{{- $defaults := 0 -}}
+{{- range $entries -}}
+{{- if not (or .matchLabels .dnsZones) -}}{{- $defaults = add1 $defaults -}}{{- end -}}
+{{- end -}}
+{{- if gt $defaults 1 -}}
+{{- fail "ambiguous default solver: at most one solver entry may omit matchLabels/dnsZones" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render a solver selector block from an entry's matchLabels / dnsZones.
+Renders nothing when the entry has neither (the default/catch-all solver).
+*/}}
+{{- define "create-issuer.solverSelector" -}}
+{{- if or .matchLabels .dnsZones }}
+selector:
+  {{- with .matchLabels }}
+  matchLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .dnsZones }}
+  dnsZones:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/gitops/components/cert-manager/create-issuer/templates/create-issuer.yaml
+++ b/gitops/components/cert-manager/create-issuer/templates/create-issuer.yaml
@@ -1,3 +1,4 @@
+{{- include "create-issuer.validate" . -}}
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -12,23 +13,23 @@ spec:
     privateKeySecretRef:
       name: {{ .Values.issuerName }}
     solvers:
+      {{- range .Values.solvers.ingress }}
       - http01:
-          {{- if and .Values.ingressClassName (not .Values.gateway.enabled) }}
           ingress:
-            class: {{ .Values.ingressClassName }}
-          {{- end }}
-          {{- if .Values.gateway.enabled }}
-          {{- if not (and .Values.gateway.name .Values.gateway.namespace) }}
-          {{- fail ".gateway.name and .gateway.namespace are required when gateway.enabled is true" }}
-          {{- end }}
+            class: {{ required "solvers.ingress entries require class" .class }}
+        {{- with include "create-issuer.solverSelector" . }}{{ . | trim | nindent 8 }}{{- end }}
+      {{- end }}
+      {{- range .Values.solvers.gateway }}
+      - http01:
           gatewayHTTPRoute:
             parentRefs:
-              - name: {{ .Values.gateway.name }}
-                namespace: {{ .Values.gateway.namespace }}
-          {{- end }}
+              - name: {{ required "solvers.gateway entries require name" .name }}
+                namespace: {{ required "solvers.gateway entries require namespace" .namespace }}
+        {{- with include "create-issuer.solverSelector" . }}{{ . | trim | nindent 8 }}{{- end }}
+      {{- end }}
+      {{- if .Values.solvers.dns01.enabled }}
       - dns01:
           route53:
             region: {{ .Values.awsRegion }}
-        selector:
-          matchLabels:
-            "use-dns01-solver": "true"
+        {{- with include "create-issuer.solverSelector" .Values.solvers.dns01 }}{{ . | trim | nindent 8 }}{{- end }}
+      {{- end }}

--- a/gitops/components/cert-manager/create-issuer/values.yaml
+++ b/gitops/components/cert-manager/create-issuer/values.yaml
@@ -15,7 +15,7 @@ solvers:
     #   matchLabels:
     #     use-traefik-solver: "true"
   # http01 solved via HTTPRoute attached to a Gateway (requires cert-manager
-  # config.enableGatewayAPI - see docs/GATEWAY-MIGRATION.md)
+  # config.enableGatewayAPI - see docs/GATEWAY-ADOPTION.md)
   gateway: []
   # - name: eg
   #   namespace: envoy-gateway-system

--- a/gitops/components/cert-manager/create-issuer/values.yaml
+++ b/gitops/components/cert-manager/create-issuer/values.yaml
@@ -17,7 +17,7 @@ solvers:
   # http01 solved via HTTPRoute attached to a Gateway (requires cert-manager
   # config.enableGatewayAPI - see docs/GATEWAY-ADOPTION.md)
   gateway: []
-  # - name: eg
+  # - name: external
   #   namespace: envoy-gateway-system
   #   matchLabels:
   #     use-gateway-solver: "true"

--- a/gitops/components/cert-manager/create-issuer/values.yaml
+++ b/gitops/components/cert-manager/create-issuer/values.yaml
@@ -1,8 +1,29 @@
 issuerName: letsencrypt
 acmeIssuerEmail: ""
 awsRegion: "us-west-2"
-ingressClassName: nginx
-gateway:
-  enabled: false
-  name: ""
-  namespace: ""
+
+# Each entry below becomes one ACME solver on the ClusterIssuer. cert-manager
+# picks the MOST SPECIFIC matching solver per Certificate (matchLabels /
+# dnsZones); at most ONE entry across all solver types may omit selectors —
+# that entry is the default/catch-all.
+solvers:
+  # http01 solved via Ingress objects (served by whichever controller claims
+  # the class — nginx and the traefik nginx-compat provider both serve `nginx`)
+  ingress:
+    - class: nginx # no matchLabels/dnsZones -> default solver
+    # - class: traefik
+    #   matchLabels:
+    #     use-traefik-solver: "true"
+  # http01 solved via HTTPRoute attached to a Gateway (requires cert-manager
+  # config.enableGatewayAPI - see docs/GATEWAY-MIGRATION.md)
+  gateway: []
+  # - name: eg
+  #   namespace: envoy-gateway-system
+  #   matchLabels:
+  #     use-gateway-solver: "true"
+  # dns01 via route53 (region from awsRegion above)
+  dns01:
+    enabled: true
+    matchLabels:
+      use-dns01-solver: "true"
+    # dnsZones: []

--- a/gitops/components/cert-manager/resources.yaml
+++ b/gitops/components/cert-manager/resources.yaml
@@ -77,7 +77,7 @@ spec:
       valuesObject:
         acmeIssuerEmail: ACME_ISSUER_EMAIL
         awsRegion: AWS_REGION
-    targetRevision: v4.6.2 # x-release-please-version
+    targetRevision: feat/traefik-ingress-component # x-release-please-version
   destination:
     namespace: cert-manager
     name: in-cluster

--- a/gitops/components/cert-manager/resources.yaml
+++ b/gitops/components/cert-manager/resources.yaml
@@ -77,7 +77,7 @@ spec:
       valuesObject:
         acmeIssuerEmail: ACME_ISSUER_EMAIL
         awsRegion: AWS_REGION
-    targetRevision: feat/traefik-ingress-component # x-release-please-version
+    targetRevision: v4.6.2 # x-release-please-version
   destination:
     namespace: cert-manager
     name: in-cluster

--- a/gitops/components/envoy-gateway/create-gateway/Chart.yaml
+++ b/gitops/components/envoy-gateway/create-gateway/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: create-gateway
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0

--- a/gitops/components/envoy-gateway/create-gateway/templates/gateway.yaml
+++ b/gitops/components/envoy-gateway/create-gateway/templates/gateway.yaml
@@ -1,8 +1,11 @@
 ---
+# Role-based names (external), per Gateway API convention: the class/gateway
+# name the platform offers, not the implementation. A future internal gateway
+# is the symmetric triple (GatewayClass/EnvoyProxy/Gateway `internal`).
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
-  name: eg
+  name: external
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
@@ -10,13 +13,13 @@ spec:
   parametersRef:
     group: gateway.envoyproxy.io
     kind: EnvoyProxy
-    name: eg-proxy
+    name: external
     namespace: envoy-gateway-system
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:
-  name: eg-proxy
+  name: external
   namespace: envoy-gateway-system
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
@@ -35,12 +38,19 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: eg
+  name: external
   namespace: envoy-gateway-system
+  # Intent-free by design: no cert-manager issuer annotation and no solver
+  # label. Certificate intent lives on each app's ListenerSet (issuer
+  # annotation + use-gateway-solver label). If a TLS listener is ever added
+  # here via gateway.extraListeners, choose its Certificate's solver
+  # deliberately at that time — labels inherited from this Gateway feed
+  # cert-manager's solver selection, and wildcards require the dns01 solver
+  # (use-dns01-solver label or dnsZones).
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  gatewayClassName: eg
+  gatewayClassName: external
   allowedListeners:
     namespaces:
       from: All

--- a/gitops/components/envoy-gateway/create-gateway/templates/gateway.yaml
+++ b/gitops/components/envoy-gateway/create-gateway/templates/gateway.yaml
@@ -57,7 +57,7 @@ spec:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if and (not .Values.gateway.acmeSolver) (not .Values.gateway.extraListeners) }}
-    # a Gateway must carry at least one listener even when all real listeners
+    # HACK: a Gateway must carry at least one listener even when all real listeners
     # live in ListenerSets; drop this once
     # https://github.com/kubernetes-sigs/gateway-api/issues/4425 is resolved
     - name: placeholder

--- a/gitops/components/envoy-gateway/create-gateway/templates/gateway.yaml
+++ b/gitops/components/envoy-gateway/create-gateway/templates/gateway.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: eg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: eg-proxy
+    namespace: envoy-gateway-system
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: eg-proxy
+  namespace: envoy-gateway-system
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyService:
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+          service.beta.kubernetes.io/aws-load-balancer-name: "{{ .Values.nlbName }}"
+          service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
+          service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
+          service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: eg
+  namespace: envoy-gateway-system
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  gatewayClassName: eg
+  allowedListeners:
+    namespaces:
+      from: All
+  listeners:
+    {{- if .Values.gateway.acmeSolver }}
+    - name: acme-solver
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
+    {{- end }}
+    {{- with .Values.gateway.extraListeners }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if and (not .Values.gateway.acmeSolver) (not .Values.gateway.extraListeners) }}
+    # a Gateway must carry at least one listener even when all real listeners
+    # live in ListenerSets; drop this once
+    # https://github.com/kubernetes-sigs/gateway-api/issues/4425 is resolved
+    - name: placeholder
+      port: 65535
+      protocol: HTTP
+      hostname: placeholder.invalid
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              placeholder: placeholder
+    {{- end }}

--- a/gitops/components/envoy-gateway/create-gateway/values.yaml
+++ b/gitops/components/envoy-gateway/create-gateway/values.yaml
@@ -11,5 +11,5 @@ gateway:
   acmeSolver: true
   # Additional Gateway listeners, appended verbatim (Gateway API listener
   # schema). Most per-host TLS config should use ListenerSets instead — see
-  # docs/GATEWAY-MIGRATION.md.
+  # docs/GATEWAY-ADOPTION.md.
   extraListeners: []

--- a/gitops/components/envoy-gateway/create-gateway/values.yaml
+++ b/gitops/components/envoy-gateway/create-gateway/values.yaml
@@ -1,0 +1,15 @@
+nlbName: "EG_NLB_NAME"
+
+gateway:
+  # Renders a real HTTP :80 listener for cert-manager's http01 gatewayHTTPRoute
+  # solver (allowedRoutes from All — cert-manager creates challenge HTTPRoutes
+  # in the app's namespace). This also satisfies the Gateway API's >=1 listener
+  # requirement. Disable only on clusters that must not expose port 80
+  # (e.g. dns01-only): a placeholder listener is rendered instead until
+  # https://github.com/kubernetes-sigs/gateway-api/issues/4425 allows
+  # listener-less Gateways.
+  acmeSolver: true
+  # Additional Gateway listeners, appended verbatim (Gateway API listener
+  # schema). Most per-host TLS config should use ListenerSets instead — see
+  # docs/GATEWAY-MIGRATION.md.
+  extraListeners: []

--- a/gitops/components/envoy-gateway/kustomization.yaml
+++ b/gitops/components/envoy-gateway/kustomization.yaml
@@ -38,7 +38,7 @@ patches:
   # Ingress solver remains the selector-less default; Certificates opt in by
   # carrying the use-gateway-solver label (set it on the Gateway/ListenerSet —
   # shim-created Certificates inherit its labels). parentRefs assume the
-  # conventional `eg` Gateway in envoy-gateway-system (see GATEWAY-MIGRATION.md).
+  # conventional `eg` Gateway in envoy-gateway-system (see GATEWAY-ADOPTION.md).
   - target:
       group: argoproj.io
       version: v1alpha1

--- a/gitops/components/envoy-gateway/kustomization.yaml
+++ b/gitops/components/envoy-gateway/kustomization.yaml
@@ -36,9 +36,10 @@ patches:
                   ListenerSets: true
   # Adds a labeled gateway solver to the letsencrypt ClusterIssuer. The
   # Ingress solver remains the selector-less default; Certificates opt in by
-  # carrying the use-gateway-solver label (set it on the Gateway/ListenerSet —
+  # carrying the use-gateway-solver label (set it on the ListenerSet —
   # shim-created Certificates inherit its labels). parentRefs assume the
-  # conventional `eg` Gateway in envoy-gateway-system (see GATEWAY-ADOPTION.md).
+  # `external` Gateway created by this component's create-gateway chart
+  # (see GATEWAY-ADOPTION.md).
   - target:
       group: argoproj.io
       version: v1alpha1
@@ -55,7 +56,7 @@ patches:
             valuesObject:
               solvers:
                 gateway:
-                  - name: eg
+                  - name: external
                     namespace: envoy-gateway-system
                     matchLabels:
                       use-gateway-solver: "true"

--- a/gitops/components/envoy-gateway/kustomization.yaml
+++ b/gitops/components/envoy-gateway/kustomization.yaml
@@ -4,7 +4,100 @@ kind: Component
 resources:
   - ./resources.yaml
 
+# Enabling this component automatically turns on Gateway API support in
+# cert-manager (gateway-shim + ListenerSets) and external-dns (gateway-httproute
+# source). Both controllers crash-loop if these are enabled without the Gateway
+# API CRDs — which ship with the envoy-gateway chart — hence the toggles live
+# here, not in their own components.
+# ORDERING MATTERS: the cert-manager and external-dns components must be listed
+# BEFORE envoy-gateway in the consumer's `components:` array. If one is missing
+# or listed after, kustomize SILENTLY SKIPS that patch — gateway certificates
+# won't issue / gateway DNS records won't publish.
+patches:
+  - target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+      name: cert-manager
+    patch: |-
+      apiVersion: argoproj.io/v1alpha1
+      kind: Application
+      metadata:
+        name: cert-manager
+      spec:
+        source:
+          helm:
+            valuesObject:
+              config:
+                gatewayAPI:
+                  enabled: true
+                  enableListenerSet: true
+                featureGates:
+                  ListenerSets: true
+  # Adds a labeled gateway solver to the letsencrypt ClusterIssuer. The
+  # Ingress solver remains the selector-less default; Certificates opt in by
+  # carrying the use-gateway-solver label (set it on the Gateway/ListenerSet —
+  # shim-created Certificates inherit its labels). parentRefs assume the
+  # conventional `eg` Gateway in envoy-gateway-system (see GATEWAY-MIGRATION.md).
+  - target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+      name: create-issuer
+    patch: |-
+      apiVersion: argoproj.io/v1alpha1
+      kind: Application
+      metadata:
+        name: create-issuer
+      spec:
+        source:
+          helm:
+            valuesObject:
+              solvers:
+                gateway:
+                  - name: eg
+                    namespace: envoy-gateway-system
+                    matchLabels:
+                      use-gateway-solver: "true"
+  # Publish DNS records for all Gateway API route types (traversing
+  # ListenerSets to the parent Gateway's address). Safe to enable together:
+  # every route CRD ships with this component's gateway-helm chart, at the API
+  # versions external-dns watches (HTTPRoute/GRPCRoute v1; TLS/TCP/UDP routes
+  # v1alpha2). Notes: TCP/UDP routes carry no hostnames — records for them
+  # require the external-dns.alpha.kubernetes.io/hostname annotation on the
+  # route; external-dns's v1alpha2 route support is deprecated upstream and a
+  # future chart bump may retire those sources (fails loudly at rollout).
+  # `sources` is a whole-list replacement in helm, so the defaults
+  # (service, ingress) must be restated here; the chart regenerates
+  # external-dns's RBAC from this list automatically.
+  - target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+      name: external-dns
+    patch: |-
+      apiVersion: argoproj.io/v1alpha1
+      kind: Application
+      metadata:
+        name: external-dns
+      spec:
+        source:
+          helm:
+            valuesObject:
+              sources:
+                - service
+                - ingress
+                - gateway-httproute
+                - gateway-grpcroute
+                - gateway-tlsroute
+                - gateway-tcproute
+                - gateway-udproute
+              enableGatewayListenerSets: true
+
 replacements:
+  # The EnvoyProxy now lives in the create-gateway chart (rendered by ArgoCD at
+  # sync time), so the NLB name is substituted into the Application's chart
+  # values rather than the EnvoyProxy object itself.
   - source:
       version: v1
       kind: ConfigMap
@@ -13,9 +106,9 @@ replacements:
       fieldPath: data.EG_NLB_NAME
     targets:
       - select:
-          group: gateway.envoyproxy.io
+          group: argoproj.io
           version: v1alpha1
-          kind: EnvoyProxy
-          name: eg-proxy
+          kind: Application
+          name: envoy-gateway
         fieldPaths:
-          - spec.provider.kubernetes.envoyService.annotations.[service.beta.kubernetes.io/aws-load-balancer-name]
+          - spec.sources.[path=gitops/components/envoy-gateway/create-gateway].helm.valuesObject.nlbName

--- a/gitops/components/envoy-gateway/resources.yaml
+++ b/gitops/components/envoy-gateway/resources.yaml
@@ -18,7 +18,7 @@ spec:
         releaseName: envoy-gateway
     - repoURL: "https://github.com/pelotech/foundation"
       path: gitops/components/envoy-gateway/create-gateway
-      targetRevision: v4.6.2 # x-release-please-version
+      targetRevision: feat/traefik-ingress-component # x-release-please-version
       helm:
         releaseName: create-gateway
         valuesObject:

--- a/gitops/components/envoy-gateway/resources.yaml
+++ b/gitops/components/envoy-gateway/resources.yaml
@@ -18,7 +18,7 @@ spec:
         releaseName: envoy-gateway
     - repoURL: "https://github.com/pelotech/foundation"
       path: gitops/components/envoy-gateway/create-gateway
-      targetRevision: feat/traefik-ingress-component # x-release-please-version
+      targetRevision: v4.6.2 # x-release-please-version
       helm:
         releaseName: create-gateway
         valuesObject:

--- a/gitops/components/envoy-gateway/resources.yaml
+++ b/gitops/components/envoy-gateway/resources.yaml
@@ -10,12 +10,19 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   project: networking
-  source:
-    chart: gateway-helm
-    repoURL: docker.io/envoyproxy
-    targetRevision: v1.8.0
-    helm:
-      releaseName: envoy-gateway
+  sources:
+    - chart: gateway-helm
+      repoURL: docker.io/envoyproxy
+      targetRevision: v1.8.0
+      helm:
+        releaseName: envoy-gateway
+    - repoURL: "https://github.com/pelotech/foundation"
+      path: gitops/components/envoy-gateway/create-gateway
+      targetRevision: v4.6.2 # x-release-please-version
+      helm:
+        releaseName: create-gateway
+        valuesObject:
+          nlbName: EG_NLB_NAME
   destination:
     namespace: envoy-gateway-system
     name: in-cluster
@@ -24,39 +31,3 @@ spec:
       - CreateNamespace=true
       - ServerSideApply=true
     automated: {}
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: GatewayClass
-metadata:
-  name: eg
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-spec:
-  controllerName: gateway.envoyproxy.io/gatewayclass-controller
-  parametersRef:
-    group: gateway.envoyproxy.io
-    kind: EnvoyProxy
-    name: eg-proxy
-    namespace: envoy-gateway-system
----
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: EnvoyProxy
-metadata:
-  name: eg-proxy
-  namespace: envoy-gateway-system
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-spec:
-  provider:
-    type: Kubernetes
-    kubernetes:
-      envoyService:
-        annotations:
-          service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
-          # TODO: once nginx ingress migration is complete, EG_NLB_NAME can be replaced with CLUSTER_NAME
-          service.beta.kubernetes.io/aws-load-balancer-name: EG_NLB_NAME
-          service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
-          # nlb-target-type: ip requires pod IPs to be registered as EC2 ENIs, which depends
-          # on the CNI and IPAM configuration. Instance mode targets nodes via NodePort instead.
-          service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
-          service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"

--- a/gitops/components/envoy-gateway/resources.yaml
+++ b/gitops/components/envoy-gateway/resources.yaml
@@ -13,7 +13,7 @@ spec:
   sources:
     - chart: gateway-helm
       repoURL: docker.io/envoyproxy
-      targetRevision: v1.8.0
+      targetRevision: v1.8.3
       helm:
         releaseName: envoy-gateway
     - repoURL: "https://github.com/pelotech/foundation"

--- a/gitops/components/ingress-nginx/README.md
+++ b/gitops/components/ingress-nginx/README.md
@@ -1,0 +1,16 @@
+# ingress-nginx (EOL — migration window only)
+
+The [retired](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/)
+ingress-nginx controller, pinned at its terminal chart version (no further
+releases or CVE patches). Kept as a separate component only for the migration
+window — see the [`traefik`](../traefik/README.md) component for the maintained
+drop-in replacement and the cutover procedure.
+
+Requires the [`aws-alb`](../aws-alb/README.md) component (AWS Load Balancer
+Controller) to provision its NLB, which is named after `CLUSTER_NAME`.
+
+`controller.publishService.enabled` is exposed as a helm parameter (default
+`"true"`). When the `traefik` component is enabled it overrides this via the
+`NGINX_PUBLISH_SERVICE` key to coordinate which controller owns Ingress status
+(and therefore external-dns records) — see the
+[traefik README](../traefik/README.md) for the switch semantics.

--- a/gitops/components/ingress-nginx/kustomization.yaml
+++ b/gitops/components/ingress-nginx/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ./resources.yaml
+
+replacements:
+  - source:
+      version: v1
+      kind: ConfigMap
+      name: kustomize-environment
+      fieldPath: data.CLUSTER_NAME
+    targets:
+      - select:
+          group: argoproj.io
+          version: v1alpha1
+          kind: Application
+          name: ingress-nginx-controller
+        fieldPaths:
+          - spec.source.helm.valuesObject.controller.service.annotations.[service.beta.kubernetes.io/aws-load-balancer-name]

--- a/gitops/components/ingress-nginx/resources.yaml
+++ b/gitops/components/ingress-nginx/resources.yaml
@@ -2,55 +2,6 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: alb-controller
-  namespace: argocd
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
-spec:
-  project: networking
-  source:
-    chart: aws-load-balancer-controller
-    repoURL: https://aws.github.io/eks-charts
-    targetRevision: 3.4.2
-    helm:
-      releaseName: aws-load-balancer-controller
-      valuesObject:
-        hostNetwork: true
-        metricsBindAddr: ':8085'
-        serviceAccount:
-          create: "true"
-          name: "aws-load-balancer-controller"
-          annotations:
-            eks.amazonaws.com/role-arn: ALB_ROLE_ARN
-            eks.amazonaws.com/sts-regional-endpoints: "true"
-        clusterName: CLUSTER_NAME
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "128Mi"
-          limits:
-            cpu: "100m"
-            memory: "128Mi"
-        tolerations:
-          - key: CriticalAddonsOnly
-            operator: Exists
-#        watchNamespace: ingress-nginx # NOTE: Currently disabled however may need to bring back to limit aws lb controller.
-  ignoreDifferences:
-    - kind: Secret
-      name: aws-load-balancer-tls
-      jqPathExpressions:
-        - .data
-  destination:
-    namespace: alb
-    name: in-cluster
-  syncPolicy:
-    syncOptions:
-      - CreateNamespace=true
-    automated: {}
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
   name: ingress-nginx-controller
   namespace: argocd
   finalizers:
@@ -63,6 +14,13 @@ spec:
     targetRevision: 4.15.1
     helm:
       releaseName: ingress-nginx
+      # publishService controls whether nginx writes Ingress .status.loadBalancer
+      # (where external-dns points DNS). Default "true" preserves standalone
+      # behavior; when the traefik component is enabled, its NGINX_PUBLISH_SERVICE
+      # replacement overrides this to coordinate the status-ownership switch.
+      parameters:
+        - name: controller.publishService.enabled
+          value: "true"
       valuesObject:
         controller:
           containerPort:

--- a/gitops/components/traefik/README.md
+++ b/gitops/components/traefik/README.md
@@ -48,6 +48,14 @@ Controller) to reconcile the LoadBalancer Service into an NLB.
   only.
 * No hostNetwork/hostPort, so nginx's port-81 pod-identity workaround is not
   needed.
+* This component **owns the `nginx` IngressClass**
+  ([ingress-class.yaml](ingress-class.yaml)) and patches the ingress-nginx
+  chart to stop creating its copy — one owner throughout coexistence, and the
+  object survives nginx's removal. Without it, deleting the nginx chart
+  deletes the class and the AWS Load Balancer Controller's webhook then
+  **denies every write** to class-`nginx` Ingresses ("invalid ingress class
+  ... not found"), failing ArgoCD syncs and cert-manager http01 solver
+  creation (traffic keeps flowing — Traefik matches the class by name).
 
 ## Cutover (per cluster, when ready)
 
@@ -64,10 +72,6 @@ Controller) to reconcile the LoadBalancer Service into an NLB.
 4. Delete nginx's leftover admission webhook, or Ingress writes will fail
    against the dead webhook service:
    `kubectl delete validatingwebhookconfiguration ingress-nginx-admission`.
-   Note the nginx chart's removal also deletes the `nginx` IngressClass —
-   Traefik matches the class by name so existing Ingresses keep working, but
-   recreate an `nginx` IngressClass (marked default) if consumers create
-   class-less Ingresses.
 5. Delete the old NLB; hunt orphans via
    [CLEANUP.md](../../../docs/CLEANUP.md) tags. `TRAEFIK_NLB_NAME` can then be
    replaced with `CLUSTER_NAME`.

--- a/gitops/components/traefik/README.md
+++ b/gitops/components/traefik/README.md
@@ -55,7 +55,7 @@ Controller) to reconcile the LoadBalancer Service into an NLB.
    (edit `/etc/hosts` or `curl --resolve`) — Ingresses are already live on it.
 2. Optionally shift per-host with Route53 weighted records
    (`external-dns.alpha.kubernetes.io/aws-weight` + `set-identifier`), as in
-   [GATEWAY-MIGRATION.md](../../../docs/GATEWAY-MIGRATION.md).
+   [GATEWAY-ADOPTION.md](../../../docs/GATEWAY-ADOPTION.md).
 3. Flip the switch: `TRAEFIK_PUBLISH_SERVICE: "true"` +
    `NGINX_PUBLISH_SERVICE: "false"` — Ingress statuses (and external-dns
    records) move to the Traefik NLB. Rollback is flipping the pair back. Once

--- a/gitops/components/traefik/README.md
+++ b/gitops/components/traefik/README.md
@@ -1,0 +1,93 @@
+# Traefik (Ingress API controller, nginx drop-in)
+
+Replaces the retired [ingress-nginx](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/)
+controller with a maintained one, **without consumer changes**: Traefik's
+[`kubernetesIngressNGINX` provider](https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-ingress-nginx/)
+claims IngressClass `nginx` (controller `k8s.io/ingress-nginx`) and natively
+interprets `nginx.ingress.kubernetes.io/*` annotations, so existing Ingresses —
+including cert-manager's http01 solver Ingresses — keep working verbatim.
+
+Gateway API is deliberately **not** enabled here; the `envoy-gateway` component
+owns that surface.
+
+## Required `kustomize-environment` keys
+
+| Key | Purpose |
+|---|---|
+| `TRAEFIK_NLB_NAME` | Name of the NLB fronting Traefik (e.g. `traefik-CLUSTER-NAME`). Kept distinct from `CLUSTER_NAME` so this NLB coexists with ingress-nginx's during migration. |
+| `TRAEFIK_PUBLISH_SERVICE` | `"true"`/`"false"` — whether Traefik writes Ingress `.status.loadBalancer` (where external-dns points DNS). |
+| `NGINX_PUBLISH_SERVICE` | `"true"`/`"false"` — same switch for the ingress-nginx Application (cross-component; ignored once nginx is removed). |
+
+**Exactly one** of the two `*_PUBLISH_SERVICE` keys may be `"true"`: both true
+makes external-dns flap between the NLBs; both false makes external-dns
+(`policy: sync`) **delete** the records. Start with nginx `"true"` / traefik
+`"false"`; flipping the pair switches DNS between the controllers — in either
+direction — without touching any Ingress. Ordering: list the
+`aws-alb-nginx`/`ingress-nginx` component **before** `traefik` in
+`components:` so the cross-component replacement finds its target.
+
+The `networking` AppProject must allow `ghcr.io/traefik/helm` in `sourceRepos`
+and the `traefik` namespace in `destinations`.
+
+Requires the [`aws-alb`](../aws-alb/README.md) component (AWS Load Balancer
+Controller) to reconcile the LoadBalancer Service into an NLB.
+
+## Coexistence design (why the switch has no impact)
+
+* Traefik gets its **own NLB** (`TRAEFIK_NLB_NAME`); ingress-nginx keeps its
+  NLB and its traffic. Nothing changes for consumers on deploy.
+* Ingress-status ownership is a **switch**: with `TRAEFIK_PUBLISH_SERVICE:
+  "false"` / `NGINX_PUBLISH_SERVICE: "true"`, only ingress-nginx writes Ingress
+  `.status.loadBalancer`, so external-dns records keep pointing at the nginx
+  NLB. Flipping the pair moves DNS to Traefik's NLB — and flipping back rolls
+  it back — with no Ingress changes.
+* Real client IP parity: the NLB target groups use `proxy_protocol_v2` and the
+  entryPoints trust PROXY protocol from `0.0.0.0/0` — the same trust posture
+  as nginx's `proxy-real-ip-cidr` default. Clients can't spoof through the NLB
+  (it prepends its own PROXY header); direct pod connections are VPC-internal
+  only.
+* No hostNetwork/hostPort, so nginx's port-81 pod-identity workaround is not
+  needed.
+
+## Cutover (per cluster, when ready)
+
+1. Verify serving: resolve a host against the Traefik NLB directly
+   (edit `/etc/hosts` or `curl --resolve`) — Ingresses are already live on it.
+2. Optionally shift per-host with Route53 weighted records
+   (`external-dns.alpha.kubernetes.io/aws-weight` + `set-identifier`), as in
+   [GATEWAY-MIGRATION.md](../../../docs/GATEWAY-MIGRATION.md).
+3. Flip the switch: `TRAEFIK_PUBLISH_SERVICE: "true"` +
+   `NGINX_PUBLISH_SERVICE: "false"` — Ingress statuses (and external-dns
+   records) move to the Traefik NLB. Rollback is flipping the pair back. Once
+   confident, remove the `ingress-nginx` component (or the aggregate's nginx
+   half).
+4. Delete nginx's leftover admission webhook, or Ingress writes will fail
+   against the dead webhook service:
+   `kubectl delete validatingwebhookconfiguration ingress-nginx-admission`.
+   Note the nginx chart's removal also deletes the `nginx` IngressClass —
+   Traefik matches the class by name so existing Ingresses keep working, but
+   recreate an `nginx` IngressClass (marked default) if consumers create
+   class-less Ingresses.
+5. Delete the old NLB; hunt orphans via
+   [CLEANUP.md](../../../docs/CLEANUP.md) tags. `TRAEFIK_NLB_NAME` can then be
+   replaced with `CLUSTER_NAME`.
+
+## Known compatibility gaps vs ingress-nginx
+
+Audit consumer Ingresses against the
+[supported annotations list](https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/)
+before cutover. Highlights:
+
+* snippet annotations are **enabled** for nginx parity, but only a directive
+  subset is parsed (`add_header`, `proxy_set_header`, `more_set_headers`,
+  `set`, `if`, `return`, ...) with common `$var` interpolation — raw nginx
+  config (Lua, tuning directives) is never executed. Audit snippets against
+  the supported list. Note that in multi-tenant clusters `proxy_set_header`
+  still lets any Ingress-creating namespace spoof headers upstreams may trust;
+  once snippet users have migrated, disable this per cluster
+  (`allowSnippetAnnotations: false` via an ArgoCD Application patch).
+* mTLS: `auth-tls-secret`/`auth-tls-verify-client`/`auth-tls-pass-certificate-to-upstream`
+  work; failed validation rejects at the TLS handshake instead of returning
+  nginx's `400`. `auth-tls-match-cn` and `auth-tls-error-page` are unsupported.
+* `ssl-passthrough` only for single-path/rule Ingresses; `auth-tls-verify-depth`
+  is accepted but not enforced.

--- a/gitops/components/traefik/ingress-class.yaml
+++ b/gitops/components/traefik/ingress-class.yaml
@@ -1,0 +1,19 @@
+---
+# The `nginx` IngressClass, owned by the traefik component. While ingress-nginx
+# is still installed, this component patches its chart to stop creating the
+# same-named object (see kustomization.yaml), so there is exactly one owner —
+# and removing nginx later never deletes the class. That matters because the
+# AWS Load Balancer Controller's validating webhook (vingress.elbv2.k8s.aws)
+# resolves the IngressClass of every Ingress write and DENIES the request when
+# the object is missing (breaking ArgoCD syncs and cert-manager http01 solver
+# creation). Both controllers serve the class: ingress-nginx claims it via
+# spec.controller, traefik's nginx-compat provider matches it by name.
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: nginx
+  annotations:
+    # nginx was the cluster default; preserve class-less Ingress behavior
+    ingressclass.kubernetes.io/is-default-class: "true"
+spec:
+  controller: k8s.io/ingress-nginx

--- a/gitops/components/traefik/kustomization.yaml
+++ b/gitops/components/traefik/kustomization.yaml
@@ -3,6 +3,32 @@ kind: Component
 
 resources:
   - ./resources.yaml
+  - ./ingress-class.yaml
+
+# Transfers ownership of the `nginx` IngressClass from the ingress-nginx chart
+# to this component (see ingress-class.yaml): the chart stops rendering the
+# object, and since the nginx Application syncs without prune, the existing
+# object persists until this component's copy adopts it — the class is never
+# absent. Silently skipped once ingress-nginx is removed (same cross-component
+# pattern and ordering rule as the publishService replacement below).
+patches:
+  - target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+      name: ingress-nginx-controller
+    patch: |-
+      apiVersion: argoproj.io/v1alpha1
+      kind: Application
+      metadata:
+        name: ingress-nginx-controller
+      spec:
+        source:
+          helm:
+            valuesObject:
+              controller:
+                ingressClassResource:
+                  enabled: false
 
 replacements:
   - source:

--- a/gitops/components/traefik/kustomization.yaml
+++ b/gitops/components/traefik/kustomization.yaml
@@ -1,0 +1,55 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ./resources.yaml
+
+replacements:
+  - source:
+      version: v1
+      kind: ConfigMap
+      name: kustomize-environment
+      # TODO: once nginx ingress migration is complete, TRAEFIK_NLB_NAME can be replaced with CLUSTER_NAME
+      fieldPath: data.TRAEFIK_NLB_NAME
+    targets:
+      - select:
+          group: argoproj.io
+          version: v1alpha1
+          kind: Application
+          name: traefik
+        fieldPaths:
+          - spec.source.helm.valuesObject.service.annotations.[service.beta.kubernetes.io/aws-load-balancer-name]
+
+  # Ingress-status ownership switch: EXACTLY ONE of TRAEFIK_PUBLISH_SERVICE /
+  # NGINX_PUBLISH_SERVICE may be "true" (see resources.yaml comment). Flipping
+  # the pair moves external-dns records between the two NLBs — in either
+  # direction — without touching any Ingress.
+  - source:
+      version: v1
+      kind: ConfigMap
+      name: kustomize-environment
+      fieldPath: data.TRAEFIK_PUBLISH_SERVICE
+    targets:
+      - select:
+          group: argoproj.io
+          version: v1alpha1
+          kind: Application
+          name: traefik
+        fieldPaths:
+          - spec.source.helm.parameters.[name=providers.kubernetesIngressNGINX.publishService.enabled].value
+  # Cross-component: targets the ingress-nginx Application when it is present
+  # (list ingress-nginx/aws-alb-nginx BEFORE traefik in `components:`).
+  # Silently skips once nginx is removed from the cluster.
+  - source:
+      version: v1
+      kind: ConfigMap
+      name: kustomize-environment
+      fieldPath: data.NGINX_PUBLISH_SERVICE
+    targets:
+      - select:
+          group: argoproj.io
+          version: v1alpha1
+          kind: Application
+          name: ingress-nginx-controller
+        fieldPaths:
+          - spec.source.helm.parameters.[name=controller.publishService.enabled].value

--- a/gitops/components/traefik/resources.yaml
+++ b/gitops/components/traefik/resources.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: traefik
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: networking
+  source:
+    chart: traefik
+    repoURL: ghcr.io/traefik/helm
+    targetRevision: 41.0.2
+    helm:
+      releaseName: traefik
+      # publishService controls which controller writes Ingress .status.loadBalancer
+      # (and therefore where external-dns points DNS). Wired as a helm parameter —
+      # not valuesObject — because kustomize replacements copy strings and --set
+      # coerces "true"/"false" into the booleans the chart schema requires.
+      # Replaced from TRAEFIK_PUBLISH_SERVICE; flip it (and NGINX_PUBLISH_SERVICE)
+      # to switch status ownership between the controllers. EXACTLY ONE of the two
+      # must be "true": both true -> external-dns flaps between NLBs; both false ->
+      # external-dns (policy: sync) DELETES the records.
+      parameters:
+        - name: providers.kubernetesIngressNGINX.publishService.enabled
+          value: "false"
+      valuesObject:
+        providers:
+          kubernetesIngressNGINX:
+            # Serves existing `ingressClassName: nginx` Ingresses verbatim,
+            # including nginx.ingress.kubernetes.io/* annotations:
+            # https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/ingress-nginx/
+            enabled: true
+            ingressClass: nginx
+            controllerClass: k8s.io/ingress-nginx
+            # nginx is the cluster default IngressClass today; also serve class-less Ingresses
+            watchIngressWithoutClass: true
+            # parity with nginx's strict-validate-path-type=false: without this, Traefik
+            # rejects an ENTIRE Ingress whose Prefix/Exact path contains regex characters
+            strictValidatePathType: false
+            # publishService.enabled is set via spec.source.helm.parameters above
+            # Parity with nginx's allow-snippet-annotations=true. Traefik parses a
+            # subset of directives (add_header, proxy_set_header, more_set_headers,
+            # set, if, return, ...) — it never executes raw nginx config.
+            allowSnippetAnnotations: true
+          kubernetesIngress:
+            enabled: false # nginx-compat provider only; no second ingress class
+          # kubernetesGateway stays disabled: envoy-gateway owns the Gateway API
+        ingressClass:
+          # The chart would otherwise create a `traefik` IngressClass marked default —
+          # two defaults (nginx is default today) makes the API server reject any new
+          # class-less Ingress. The nginx-compat provider matches class `nginx` by name.
+          enabled: false
+        ports:
+          # No hostNetwork/hostPort, so the pod-identity port-80 conflict that forced
+          # nginx onto containerPort 81 does not apply here.
+          # trustedIPs 0.0.0.0/0 matches nginx's proxy-real-ip-cidr default: clients
+          # can't spoof through the NLB (it prepends its own PROXY header), and direct
+          # pod connections are only reachable from inside the VPC.
+          web:
+            proxyProtocol:
+              trustedIPs:
+                - "0.0.0.0/0"
+            forwardedHeaders:
+              trustedIPs:
+                - "0.0.0.0/0"
+          websecure:
+            proxyProtocol:
+              trustedIPs:
+                - "0.0.0.0/0"
+            forwardedHeaders:
+              trustedIPs:
+                - "0.0.0.0/0"
+        service:
+          annotations:
+            service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+            service.beta.kubernetes.io/aws-load-balancer-name: TRAEFIK_NLB_NAME
+            service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
+            service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
+            service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+            service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: proxy_protocol_v2.enabled=true
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            memory: "128Mi"
+  destination:
+    namespace: traefik
+    name: in-cluster
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated: {}


### PR DESCRIPTION
## Why                                                                                                                                                                                                            
                                                                                                                                                                                                                    
  ingress-nginx is retired (archived March 2026) — our pinned chart 4.15.1 will never                                                                                                                               
  receive another release or CVE patch. This PR introduces its replacement and, along the                                                                                                                           
  way, makes the Gateway API path self-configuring.                                                                                                                                                                 
                                                                                                                                                                                                                    
  ## What                                                                                                                                                                                                           
                                                                                                                                                                                                                    
  **New `traefik` component — drop-in nginx replacement.** Traefik v3.7's GA                                                                                                                                        
  `kubernetesIngressNGINX` provider claims IngressClass `nginx` and interprets the                                                                                                                                  
  `nginx.ingress.kubernetes.io/*` annotations, so existing Ingresses — including                                                                                                                                    
  cert-manager's http01 solver Ingresses — keep working verbatim. Parity settings are                                                                                                                               
  explicit: snippet parsing on (directive subset only, never raw nginx config),                                                                                                                                     
  `strictValidatePathType: false`, proxy-protocol real client IP behind its own NLB                                                                                                                                 
  (`TRAEFIK_NLB_NAME`), no hostNetwork (the port-81 pod-identity workaround dies here),                                                                                                                             
  and the chart's default IngressClass creation is disabled (two defaults would break                                                                                                                               
  class-less Ingress admission).    

 **Reversible cutover switch.** `TRAEFIK_PUBLISH_SERVICE` / `NGINX_PUBLISH_SERVICE`                                                                                                                                
  control which controller writes Ingress `.status.loadBalancer` — i.e. where                                                                                                                                       
  external-dns points DNS. Wired as ArgoCD helm `parameters` (string→bool coercion via                                                                                                                              
  `--set`; valuesObject replacements can't carry booleans). Flip the pair to cut over,                                                                                                                              
  flip back to roll back; exactly one may be `"true"` (both true = record flapping, both                                                                                                                            
  false = external-dns `policy: sync` deletes records).                                                                                                                                                             
                                                                                                                                                                                                                    
  **Component split.** `aws-alb-nginx` → `aws-alb` (AWS Load Balancer Controller, the                                                                                                                               
  shared base for nginx/traefik/envoy-gateway) + `ingress-nginx` (EOL, kept for the                                                                                                                                 
  migration window). `aws-alb-nginx` remains as a nested-component aggregate —                                                                                                                                      
  **verified byte-identical build output**, so existing consumers are unaffected.                                                                                                                                   
                                                                                                                                                                                                                    
  **Composable ACME solvers.** The `create-issuer` chart now renders any mix of                                                                                                                                     
  http01-via-Ingress (per class), http01-via-Gateway (per Gateway), and dns01 solvers,                                                                                                                              
  selected by `matchLabels`/`dnsZones`; rendering fails on ambiguous defaults or invalid                                                                                                                            
  gateway entries. Only `ACME_ISSUER_EMAIL`/`AWS_REGION` were ever overridden, so no                                                                                                                                
  consumer migration is needed. 

  **Self-configuring Gateway API path.** Enabling `envoy-gateway` (after cert-manager                                                                                                                               
  and external-dns in `components:`) now automatically: installs the Gateway API CRDs +                                                                                                                             
  GatewayClass + EnvoyProxy + the `eg` Gateway with an `acme-solver` :80 listener                                                                                                                                   
  (via the new `create-gateway` chart; `gateway.acmeSolver: false` renders the                                                                                                                                      
  placeholder listener instead, pending gateway-api#4425); enables cert-manager's                                                                                                                                   
  gateway-shim + ListenerSet feature gates; adds a labeled gateway solver to the                                                                                                                                    
  ClusterIssuer; and enables all external-dns gateway route sources with ListenerSet                                                                                                                                
  traversal. Both cert-manager and external-dns crash-loop if these flags are set                                                                                                                                   
  without the CRDs, which is why the toggles live in this component rather than their                                                                                                                               
  own.                                                                                                                                                                                                              
                                                                                                                                                                                                                    
  ## Consumer impact                                                                                                                                                                                                
                                                                                                                                                                                                                    
  - Existing `aws-alb-nginx` consumers: **no changes required**.                                                                                                                                                    
  - Traefik adopters add three keys: `TRAEFIK_NLB_NAME`, `TRAEFIK_PUBLISH_SERVICE`,                                                                                                                                 
    `NGINX_PUBLISH_SERVICE` (plus the AppProject already updated here).                                                                                                                                             
  - ⚠️ Ordering rule: `cert-manager` and `external-dns` must precede `envoy-gateway`,                                                                                                                               
    and `ingress-nginx`/`aws-alb-nginx` must precede `traefik`, in `components:` —                                                                                                                                  
    kustomize skips unmatched patches/replacement-targets **silently**.                                                                                                                                             
  - GATEWAY-MIGRATION.md is much shorter: the hand-written Gateway, cert-manager patch,                                                                                                                             
    and external-dns patch steps are all automatic now. 